### PR TITLE
CLJ-2619: Fix agents+futures memory leak

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        jdk: ['8', '11', '16']
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.jdk }}
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'adopt'
+          cache: maven
+      - name: Build with Maven
+        run: mvn test

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -2023,27 +2023,66 @@
    :static true}
   [sym] (. clojure.lang.Var (find sym)))
 
+;if restore? is false (default), bindings should be manually cleared to prevent memory leak
 (defn binding-conveyor-fn
   {:private true
    :added "1.3"}
-  [f]
-  (let [frame (clojure.lang.Var/cloneThreadBindingFrame)]
-    (fn 
-      ([]
-         (clojure.lang.Var/resetThreadBindingFrame frame)
-         (f))
-      ([x]
-         (clojure.lang.Var/resetThreadBindingFrame frame)
-         (f x))
-      ([x y]
-         (clojure.lang.Var/resetThreadBindingFrame frame)
-         (f x y))
-      ([x y z]
-         (clojure.lang.Var/resetThreadBindingFrame frame)
-         (f x y z))
-      ([x y z & args] 
-         (clojure.lang.Var/resetThreadBindingFrame frame)
-         (apply f x y z args)))))
+  ([f] (binding-conveyor-fn f false))
+  ([f restore?]
+   (let [frame (clojure.lang.Var/cloneThreadBindingFrame)]
+     (if restore?
+       (fn
+         ([]
+          (let [previous-frame (clojure.lang.Var/getThreadBindingFrame)]
+            (clojure.lang.Var/resetThreadBindingFrame frame)
+            (try
+              (f)
+              (finally
+                (clojure.lang.Var/resetThreadBindingFrame previous-frame)))))
+         ([x]
+          (let [previous-frame (clojure.lang.Var/getThreadBindingFrame)]
+            (clojure.lang.Var/resetThreadBindingFrame frame)
+            (try
+              (f x)
+              (finally
+                (clojure.lang.Var/resetThreadBindingFrame previous-frame)))))
+         ([x y]
+          (let [previous-frame (clojure.lang.Var/getThreadBindingFrame)]
+            (clojure.lang.Var/resetThreadBindingFrame frame)
+            (try
+              (f x y)
+              (finally
+                (clojure.lang.Var/resetThreadBindingFrame previous-frame)))))
+         ([x y z]
+          (let [previous-frame (clojure.lang.Var/getThreadBindingFrame)]
+            (clojure.lang.Var/resetThreadBindingFrame frame)
+            (try
+              (f x y z)
+              (finally
+                (clojure.lang.Var/resetThreadBindingFrame previous-frame)))))
+         ([x y z & args] 
+          (let [previous-frame (clojure.lang.Var/getThreadBindingFrame)]
+            (clojure.lang.Var/resetThreadBindingFrame frame)
+            (try
+              (apply f x y z args)
+              (finally
+                (clojure.lang.Var/resetThreadBindingFrame previous-frame))))))
+       (fn 
+         ([]
+          (clojure.lang.Var/resetThreadBindingFrame frame)
+          (f))
+         ([x]
+          (clojure.lang.Var/resetThreadBindingFrame frame)
+          (f x))
+         ([x y]
+          (clojure.lang.Var/resetThreadBindingFrame frame)
+          (f x y))
+         ([x y z]
+          (clojure.lang.Var/resetThreadBindingFrame frame)
+          (f x y z))
+         ([x y z & args] 
+          (clojure.lang.Var/resetThreadBindingFrame frame)
+          (apply f x y z args)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Refs ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defn ^{:private true}
@@ -2110,6 +2149,8 @@
   (apply action-fn state-of-agent args)"
   {:added "1.5"}
   [executor ^clojure.lang.Agent a f & args]
+  ;clearing of conveyed bindings delegated to Agent impl in order to
+  ;first propagate them to error-handler call (if any)
   (.dispatch a (binding [*agent* a] (binding-conveyor-fn f)) args executor))
 
 (defn send
@@ -7010,7 +7051,7 @@ fails, attempts to require sym's namespace and retries."
   {:added "1.1"
    :static true}
   [f]
-  (let [f (binding-conveyor-fn f)
+  (let [f (binding-conveyor-fn f true)
         fut (.submit clojure.lang.Agent/soloExecutor ^Callable f)]
     (reify 
      clojure.lang.IDeref 

--- a/src/jvm/clojure/lang/Agent.java
+++ b/src/jvm/clojure/lang/Agent.java
@@ -103,6 +103,7 @@ static class Action implements Runnable{
 	}
 
 	static void doRun(Action action){
+		Object previousFrame = Var.getThreadBindingFrame();
 		try
 			{
 			nested.set(PersistentVector.EMPTY);
@@ -156,6 +157,7 @@ static class Action implements Runnable{
 		finally
 			{
 			nested.set(null);
+			Var.resetThreadBindingFrame(previousFrame); // clear conveyed bindings
 			}
 	}
 

--- a/test/clojure/test_clojure/parallel.clj
+++ b/test/clojure/test_clojure/parallel.clj
@@ -10,7 +10,8 @@
 
 
 (ns clojure.test-clojure.parallel
-  (:use clojure.test))
+  (:use clojure.test)
+  (:import [java.util.concurrent Executors ThreadFactory]))
 
 ;; !! Tests for the parallel library will be in a separate file clojure_parallel.clj !!
 
@@ -36,5 +37,77 @@
       @(future (dotimes [_ 3]
                  ;; we need some binding to trigger binding pop
                  (binding [*print-dup* false]
-                   (swap! a conj *test-value*))))
-      (is (= [2 2 2] @a)))))
+                   (swap! a conj *test-value*)))
+               ;; after CLJ-2619 no pop is needed
+               (swap! a conj *test-value* @(future *test-value*) @(future @(future *test-value*))))
+      (is (= (repeat 6 2) @a)))))
+
+(def ^:dynamic *my-var* :root-binding)
+
+;; this test runs a future and then attempts to retrieve the bindings on
+;; the future's thread after the future has finished. it might take a few tries
+;; for the second part to work. if it never does, prints a warning instead of failing.
+(deftest future-cleans-up-binding-conveyance
+  (let [try-flaky-test
+        (fn []
+          (let [global-solo-executor clojure.lang.Agent/soloExecutor
+                thread-count (atom 0)
+                current-thread-prm (promise)
+                local-executor (Executors/newCachedThreadPool
+                                 (reify ThreadFactory
+                                   (newThread [_ runnable]
+                                     (swap! thread-count inc)
+                                     (Thread. runnable))))]
+            (try
+              (set-agent-send-off-executor! local-executor)
+              (let [f-prm (promise)
+                    f (binding [*my-var* :thread-binding
+                                *1 :foo]
+                        (future
+                          (deliver current-thread-prm (Thread/currentThread))
+                          @f-prm))
+                    _ (set-agent-send-off-executor! global-solo-executor)
+                    ;; there's a chance other futures could have seen local-executor, so wait a bit to
+                    ;; let them start running. if this happens, since f is blocked it will force another
+                    ;; local-executor thread to be created. this will increment thread-count and 
+                    ;; trigger a retry on this test.
+                    _ (Thread/sleep 200)
+                    _ (deliver f-prm :done)
+                    _ @f
+                    _ (Thread/sleep 200) ;; encourage local-executor to reuse thread
+                    after-thread-bindings-prm (promise)
+                    result (deref (.submit local-executor
+                                           ^Callable
+                                           (fn* []
+                                             (if (= @current-thread-prm (Thread/currentThread))
+                                               (get-thread-bindings)
+                                               :wrong-thread)))
+                                  5000 ::timeout)
+                    thread-count @thread-count]
+                (cond
+                  (= 1 thread-count) result
+                  ;; something interfered
+                  :else :bad-thread-count))
+              (finally
+                (set-agent-send-off-executor! global-solo-executor)
+                (.shutdown local-executor)))))
+        flaky-test-result (reduce (fn [results _]
+                                    (let [maybe-flaky-result (try-flaky-test)]
+                                      (case maybe-flaky-result
+                                        ::timeout (throw (ex-info "Timeout" {:results (conj results maybe-flaky-result)}))
+                                        ;; retry
+                                        (:wrong-thread :bad-thread-count) (conj results maybe-flaky-result)
+                                        (reduced maybe-flaky-result))))
+                                  []
+                                  (range 50))]
+    (cond
+      (map? flaky-test-result) (let [actual-thread-bindings-after-future flaky-test-result]
+                                 (is (= {} actual-thread-bindings-after-future)))
+
+      (every? #{:wrong-thread :bad-thread-count} flaky-test-result)
+      (println (str "WARNING: " `future-cleans-up-binding-conveyance 
+                    " test was very unlucky"
+                    " and could not verify thread bindings. "
+                    flaky-test-result))
+
+      :else (throw (ex-info "Unknown result" {:result flaky-test-result})))))


### PR DESCRIPTION
https://clojure.atlassian.net/browse/CLJ-2619

Moved futures fix to https://github.com/frenchy64/clojure/pull/6 and abandoned agents fix.

Related to agents fix:
- https://clojure.atlassian.net/browse/CLJ-898
- https://clojure.atlassian.net/browse/CLJ-672
- https://clojure.atlassian.net/browse/CLJ-1125