### PR TITLE
CLJ-2619: clear future thread bindings after execution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+    timeout-minutes: 5
+    strategy:
+      matrix:
+        jdk: ['8', '11', '17', '19']
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.jdk }}
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'temurin'
+          cache: maven
+      - name: Build with Maven
+        run: mvn test
+      - name: Configure settings.xml
+        run: |
+          mkdir -p ~/.m2
+          echo "<settings><servers><server><id>clojars</id><username>${{ secrets.CLOJARS_USER }}-clojars</username><password>${{ secrets.CLOJARS_PASSWORD }}</password></server></servers></settings>" > ~/.m2/settings.xml

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ maven-classpath
 maven-classpath.properties
 .idea/
 *.iml
+.cpcache
+deps.edn
+.nrepl-*
+*.patch
+*.diff

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,38 @@
+;; https://clojure.org/dev/developing_patches#_run_an_individual_test
+{:paths ["test"
+         "target/test-classes"]
+ :deps
+ {org.clojure/clojure {:local/root "."
+                       :deps/manifest :pom} #_{:mvn/version "RELEASE"}
+  org.clojure/test.check {:mvn/version "1.1.1"}
+  org.clojure/test.generative {:mvn/version "1.0.0"}}
+ :aliases
+ {:dbg {:classpath-overrides {org.clojure/clojure "target/classes"}
+        :extra-deps {criterium/criterium {:mvn/version "0.4.4"}}}
+  :cognitest {:extra-deps {io.github.cognitect-labs/test-runner 
+                           {:git/tag "v0.5.0" :git/sha "b3fd0d2"}}
+              :main-opts ["-m" "cognitect.test-runner"]
+              :exec-fn cognitect.test-runner.api/test
+              :exec-args {:dirs ["test"]
+                          :patterns [;; FIXME clojure.test-clojure.ns-libs has a test that is sensitive to loading order
+                                     ;; FIXME clojure.test-clojure.java-interop doesn't seem to work on JDK 17 (untested on others)
+                                     ;; regex ref: https://stackoverflow.com/a/2387072
+                                     "^((?!(clojure.test-clojure.ns-libs|clojure.test-clojure.java-interop)).)*$"
+                                     ]}}
+  :test-example-script {:jvm-opts [;; from build.xml
+                                   "-Dclojure.test-clojure.exclude-namespaces=#{clojure.test-clojure.compilation.load-ns clojure.test-clojure.ns-libs-load-later}"
+                                   "-Dclojure.compiler.direct-linking=true"]
+                        :main-opts ["-e" "(load-file,\"src/script/run_test.clj\")"]}
+  :test-generative-script {:jvm-opts [;; from build.xml
+                                      "-Dclojure.compiler.direct-linking=true"]
+                           :main-opts ["-e" "(load-file,\"src/script/run_test_generative.clj\")"]}
+
+  :kaocha {:extra-deps {lambdaisland/kaocha {:mvn/version "1.60.977"}}
+           :exec-fn kaocha.runner/exec-fn
+           :exec-args {;:watch? true
+                       :tests [{:id          :unit
+                                :test-paths  ["test"]
+                                :ns-patterns [".*"]}]
+                       :reporter kaocha.report/dots
+                       ;; :plugins [:kaocha.plugin/profiling :kaocha.plugin/notifier]
+                       }}}}

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -2036,27 +2036,35 @@
    :static true}
   [sym] (. clojure.lang.Var (find sym)))
 
+;if clear? is false (default), bindings will persist after returned
+;function finishes executing.
 (defn binding-conveyor-fn
   {:private true
    :added "1.3"}
-  [f]
-  (let [frame (clojure.lang.Var/cloneThreadBindingFrame)]
-    (fn 
-      ([]
-         (clojure.lang.Var/resetThreadBindingFrame frame)
-         (f))
-      ([x]
-         (clojure.lang.Var/resetThreadBindingFrame frame)
-         (f x))
-      ([x y]
-         (clojure.lang.Var/resetThreadBindingFrame frame)
-         (f x y))
-      ([x y z]
-         (clojure.lang.Var/resetThreadBindingFrame frame)
-         (f x y z))
-      ([x y z & args] 
-         (clojure.lang.Var/resetThreadBindingFrame frame)
-         (apply f x y z args)))))
+  ([f] (binding-conveyor-fn f false))
+  ([f clear?]
+   (let [frame (clojure.lang.Var/cloneThreadBindingFrame)]
+     (fn
+       ([]
+        (clojure.lang.Var/resetThreadBindingFrame frame)
+        (try (f)
+             (finally (when clear? (clojure.lang.Var/resetThreadBindingFrame)))))
+       ([x]
+        (clojure.lang.Var/resetThreadBindingFrame frame)
+        (try (f x)
+             (finally (when clear? (clojure.lang.Var/resetThreadBindingFrame)))))
+       ([x y]
+        (clojure.lang.Var/resetThreadBindingFrame frame)
+        (try (f x y)
+             (finally (when clear? (clojure.lang.Var/resetThreadBindingFrame)))))
+       ([x y z]
+        (clojure.lang.Var/resetThreadBindingFrame frame)
+        (try (f x y z)
+             (finally (when clear? (clojure.lang.Var/resetThreadBindingFrame)))))
+       ([x y z & args]
+        (clojure.lang.Var/resetThreadBindingFrame frame)
+        (try (apply f x y z args)
+             (finally (when clear? (clojure.lang.Var/resetThreadBindingFrame)))))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Refs ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defn ^{:private true}
@@ -7045,7 +7053,7 @@ fails, attempts to require sym's namespace and retries."
   {:added "1.1"
    :static true}
   [f]
-  (let [f (binding-conveyor-fn f)
+  (let [f (binding-conveyor-fn f true)
         fut (.submit clojure.lang.Agent/soloExecutor ^Callable f)]
     (reify 
      clojure.lang.IDeref 

--- a/src/jvm/clojure/lang/Var.java
+++ b/src/jvm/clojure/lang/Var.java
@@ -101,6 +101,10 @@ public static Object cloneThreadBindingFrame(){
 	return dvals.get().clone();
 }
 
+public static void resetThreadBindingFrame(){
+	dvals.remove();
+}
+
 public static void resetThreadBindingFrame(Object frame){
 	dvals.set((Frame) frame);
 }

--- a/test/clojure/test_clojure/parallel.clj
+++ b/test/clojure/test_clojure/parallel.clj
@@ -10,7 +10,8 @@
 
 
 (ns clojure.test-clojure.parallel
-  (:use clojure.test))
+  (:use clojure.test)
+  (:import [java.util.concurrent Executors ThreadFactory]))
 
 ;; !! Tests for the parallel library will be in a separate file clojure_parallel.clj !!
 
@@ -36,5 +37,77 @@
       @(future (dotimes [_ 3]
                  ;; we need some binding to trigger binding pop
                  (binding [*print-dup* false]
-                   (swap! a conj *test-value*))))
-      (is (= [2 2 2] @a)))))
+                   (swap! a conj *test-value*)))
+               ;; after CLJ-2619 no pop is needed
+               (swap! a conj *test-value* @(future *test-value*) @(future @(future *test-value*))))
+      (is (= (repeat 6 2) @a)))))
+
+(def ^:dynamic *my-var* :root-binding)
+
+;; this test runs a future and then attempts to retrieve the bindings on
+;; the future's thread after the future has finished. it might take a few tries
+;; for the second part to work. if it never does, prints a warning instead of failing.
+(deftest future-cleans-up-binding-conveyance
+  (let [try-flaky-test
+        (fn []
+          (let [global-solo-executor clojure.lang.Agent/soloExecutor
+                thread-count (atom 0)
+                current-thread-prm (promise)
+                local-executor (Executors/newCachedThreadPool
+                                 (reify ThreadFactory
+                                   (newThread [_ runnable]
+                                     (swap! thread-count inc)
+                                     (Thread. runnable))))]
+            (try
+              (set-agent-send-off-executor! local-executor)
+              (let [f-prm (promise)
+                    f (binding [*my-var* :thread-binding
+                                *1 :foo]
+                        (future
+                          (deliver current-thread-prm (Thread/currentThread))
+                          @f-prm))
+                    _ (set-agent-send-off-executor! global-solo-executor)
+                    ;; there's a chance other futures could have seen local-executor, so wait a bit to
+                    ;; let them start running. if this happens, since f is blocked it will force another
+                    ;; local-executor thread to be created. this will increment thread-count and
+                    ;; trigger a retry on this test.
+                    _ (Thread/sleep 200)
+                    _ (deliver f-prm :done)
+                    _ @f
+                    _ (Thread/sleep 200) ;; encourage local-executor to reuse thread
+                    after-thread-bindings-prm (promise)
+                    result (deref (.submit local-executor
+                                           ^Callable
+                                           (fn* []
+                                             (if (= @current-thread-prm (Thread/currentThread))
+                                               (get-thread-bindings)
+                                               :wrong-thread)))
+                                  5000 ::timeout)
+                    thread-count @thread-count]
+                (cond
+                  (= 1 thread-count) result
+                  ;; something interfered
+                  :else :bad-thread-count))
+              (finally
+                (set-agent-send-off-executor! global-solo-executor)
+                (.shutdown local-executor)))))
+        flaky-test-result (reduce (fn [results _]
+                                    (let [maybe-flaky-result (try-flaky-test)]
+                                      (case maybe-flaky-result
+                                        ::timeout (throw (ex-info "Timeout" {:results (conj results maybe-flaky-result)}))
+                                        ;; retry
+                                        (:wrong-thread :bad-thread-count) (conj results maybe-flaky-result)
+                                        (reduced maybe-flaky-result))))
+                                  []
+                                  (range 50))]
+    (cond
+      (map? flaky-test-result) (let [actual-thread-bindings-after-future flaky-test-result]
+                                 (is (= {} actual-thread-bindings-after-future)))
+
+      (every? #{:wrong-thread :bad-thread-count} flaky-test-result)
+      (println (str "WARNING: " `future-cleans-up-binding-conveyance
+                    " test was very unlucky"
+                    " and could not verify thread bindings. "
+                    flaky-test-result))
+
+      :else (throw (ex-info "Unknown result" {:result flaky-test-result})))))


### PR DESCRIPTION
Without `agent` memory leak fix https://clojure.atlassian.net/browse/CLJ-2619