### PR TITLE
CLJ-2413: make Method enumeration deterministic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        jdk: ['8', '11', '16']
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.jdk }}
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'adopt'
+          cache: maven
+      - name: Build with Maven
+        run: mvn test

--- a/src/jvm/clojure/lang/Reflector.java
+++ b/src/jvm/clojure/lang/Reflector.java
@@ -93,11 +93,26 @@ private static Method toAccessibleSuperMethod(Method m, Object target) {
 	return null;
 }
 
+private static int paramsTiebreaker(Class[] ps1, Class[] ps2) {
+	final int n = ps1.length;
+	for (int i = 0; i < n; i++) {
+		int ret = ps1[i].getName().compareTo(ps2[i].getName());
+		if (ret != 0) return ret;
+	}
+	return 0;
+}
+
+private static Comparator<Method> methodComparator() {
+    return Comparator.comparing((Method m) -> m.getReturnType().getName())
+	              .thenComparing(Method::getParameterTypes, Reflector::paramsTiebreaker);
+}
+
 public static Object invokeInstanceMethod(Object target, String methodName, Object[] args) {
 	Class c = target.getClass();
 	List methods = getMethods(c, args.length, methodName, false).stream()
 					.map(method -> toAccessibleSuperMethod(method, target))
 					.filter(method -> (method != null))
+					.sorted(methodComparator())
 					.collect(Collectors.toList());
 	return invokeMatchingMethod(methodName, methods, target, args);
 }


### PR DESCRIPTION
Java does not guarantee consistent Class::getMethods ordering
across invocations, meaning that reflective paths could do different things

This comes up most with function runnable vs. callable

To avoid non-determinism, provide a deterministic iteration order by
sorting the list of potential methods.

Sort by return type, then arg types

Tests by Ambrose Bonnaire-Sergeant.

Co-authored-by: Ambrose Bonnaire-Sergeant <ambrose@ambrosebs.com>