### PR TITLE
Directly linked protocols

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+    timeout-minutes: 5
+    strategy:
+      matrix:
+        jdk: ['8', '11', '17', '19']
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.jdk }}
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'temurin'
+          cache: maven
+      - name: Build with Maven
+        run: mvn test
+      - name: Configure settings.xml
+        run: |
+          mkdir -p ~/.m2
+          echo "<settings><servers><server><id>clojars</id><username>${{ secrets.CLOJARS_USER }}-clojars</username><password>${{ secrets.CLOJARS_PASSWORD }}</password></server></servers></settings>" > ~/.m2/settings.xml

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ maven-classpath
 maven-classpath.properties
 .idea/
 *.iml
+.cpcache
+deps.edn
+.nrepl-*
+*.patch
+*.diff

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,38 @@
+;; https://clojure.org/dev/developing_patches#_run_an_individual_test
+{:paths ["test"
+         "target/test-classes"]
+ :deps
+ {org.clojure/clojure {:local/root "."
+                       :deps/manifest :pom} #_{:mvn/version "RELEASE"}
+  org.clojure/test.check {:mvn/version "1.1.1"}
+  org.clojure/test.generative {:mvn/version "1.0.0"}}
+ :aliases
+ {:dbg {:classpath-overrides {org.clojure/clojure "target/classes"}
+        :extra-deps {criterium/criterium {:mvn/version "0.4.4"}}}
+  :cognitest {:extra-deps {io.github.cognitect-labs/test-runner 
+                           {:git/tag "v0.5.0" :git/sha "b3fd0d2"}}
+              :main-opts ["-m" "cognitect.test-runner"]
+              :exec-fn cognitect.test-runner.api/test
+              :exec-args {:dirs ["test"]
+                          :patterns [;; FIXME clojure.test-clojure.ns-libs has a test that is sensitive to loading order
+                                     ;; FIXME clojure.test-clojure.java-interop doesn't seem to work on JDK 17 (untested on others)
+                                     ;; regex ref: https://stackoverflow.com/a/2387072
+                                     "^((?!(clojure.test-clojure.ns-libs|clojure.test-clojure.java-interop)).)*$"
+                                     ]}}
+  :test-example-script {:jvm-opts [;; from build.xml
+                                   "-Dclojure.test-clojure.exclude-namespaces=#{clojure.test-clojure.compilation.load-ns clojure.test-clojure.ns-libs-load-later}"
+                                   "-Dclojure.compiler.direct-linking=true"]
+                        :main-opts ["-e" "(load-file,\"src/script/run_test.clj\")"]}
+  :test-generative-script {:jvm-opts [;; from build.xml
+                                      "-Dclojure.compiler.direct-linking=true"]
+                           :main-opts ["-e" "(load-file,\"src/script/run_test_generative.clj\")"]}
+
+  :kaocha {:extra-deps {lambdaisland/kaocha {:mvn/version "1.60.977"}}
+           :exec-fn kaocha.runner/exec-fn
+           :exec-args {;:watch? true
+                       :tests [{:id          :unit
+                                :test-paths  ["test"]
+                                :ns-patterns [".*"]}]
+                       :reporter kaocha.report/dots
+                       ;; :plugins [:kaocha.plugin/profiling :kaocha.plugin/notifier]
+                       }}}}

--- a/src/clj/clojure/core_deftype.clj
+++ b/src/clj/clojure/core_deftype.clj
@@ -590,6 +590,7 @@
 
 (defn- emit-method-def [on-interface method on-method arglists extend-via-meta]
   (let [methodk (keyword method)
+        ;; extra var indirection per call if not directly linked
         gthis (with-meta method {:tag 'clojure.lang.AFunction})
         ginterf
             `(fn
@@ -695,9 +696,8 @@
      ~(when sigs
         `(#'assert-same-protocol (var ~name) '~(map :name (vals sigs))))
      ~@(map (fn [s]
-              (doto (emit-method-def (:on-interface opts) (:name s) (:on s) (:arglists s)
-                               (:extend-via-metadata opts))
-                prn))
+              (emit-method-def (:on-interface opts) (:name s) (:on s) (:arglists s)
+                               (:extend-via-metadata opts)))
             (vals sigs))
      (alter-var-root (var ~name) merge 
                      (assoc ~opts 

--- a/src/clj/clojure/core_deftype.clj
+++ b/src/clj/clojure/core_deftype.clj
@@ -597,8 +597,7 @@
                   (fn [args]
                     (let [gargs (map #(gensym (str "gf__" % "__")) args)
                           target (first gargs)
-                          interf `(fn [~@gargs] (. ~(with-meta target {:tag on-interface}) (~(or on-method method) ~@(rest gargs))))
-                          gf (gensym)]
+                          interf `(fn [~@gargs] (. ~(with-meta target {:tag on-interface}) (~(or on-method method) ~@(rest gargs))))]
                       (if extend-via-meta
                         `([~@gargs]
                             (let [cache# (.__methodImplCache ~gthis)

--- a/src/clj/clojure/core_deftype.clj
+++ b/src/clj/clojure/core_deftype.clj
@@ -591,34 +591,34 @@
 (defn- emit-method-builder [on-interface method on-method arglists extend-via-meta]
   (let [methodk (keyword method)
         gthis (with-meta (gensym) {:tag 'clojure.lang.AFunction})]
-    `(let [^clojure.lang.AFunction f#
-           (fn ~gthis
-             ~@(map 
-                 (fn [args]
-                   (let [gargs (map #(gensym (str "gf__" % "__")) args)
-                         target (first gargs)
-                         interf `(fn [~@gargs] (. ~(with-meta target {:tag on-interface}) (~(or on-method method) ~@(rest gargs))))
-                         gf (gensym)]
-                     (if extend-via-meta
-                       `([~@gargs]
-                         (let [cache# (.__methodImplCache ~gthis)
-                               fentry# (.fnEntryFor cache# (clojure.lang.Util/classOf ~target))
-                               f# (when fentry# (.fn fentry#))]
-                           (if (and fentry# (.isInterface fentry#))
-                             (f# ~@gargs)
-                             (if-let [meta# (when-let [m# (meta ~target)] ((.sym cache#) m#))]
-                               (meta# ~@gargs)
-                               (if f#
-                                 (f# ~@gargs)
-                                 ((-cache-protocol-fn ~gthis ~target ~on-interface ~interf) ~@gargs))))))
-                       `([~@gargs]
-                         (let [cache# (.__methodImplCache ~gthis)
-                               f# (.fnFor cache# (clojure.lang.Util/classOf ~target))]
-                           (if f#
-                             (f# ~@gargs)
-                             ((-cache-protocol-fn ~gthis ~target ~on-interface ~interf) ~@gargs)))))))
-                 arglists))]
-       (fn [cache#]
+      `(let [^clojure.lang.AFunction f#
+             (fn ~gthis
+               ~@(map 
+                  (fn [args]
+                    (let [gargs (map #(gensym (str "gf__" % "__")) args)
+                          target (first gargs)
+                          interf `(fn [~@gargs] (. ~(with-meta target {:tag on-interface}) (~(or on-method method) ~@(rest gargs))))
+                          gf (gensym)]
+                      (if extend-via-meta
+                        `([~@gargs]
+                            (let [cache# (.__methodImplCache ~gthis)
+                                  fentry# (.fnEntryFor cache# (clojure.lang.Util/classOf ~target))
+                                  f# (when fentry# (.fn fentry#))]
+                              (if (and fentry# (.isInterface fentry#))
+                                (f# ~@gargs)
+                                (if-let [meta# (when-let [m# (meta ~target)] ((.sym cache#) m#))]
+                                  (meta# ~@gargs)
+                                  (if f#
+                                    (f# ~@gargs)
+                                    ((-cache-protocol-fn ~gthis ~target ~on-interface ~interf) ~@gargs))))))
+                        `([~@gargs]
+                            (let [cache# (.__methodImplCache ~gthis)
+                                  f# (.fnFor cache# (clojure.lang.Util/classOf ~target))]
+                              (if f#
+                                (f# ~@gargs)
+                                ((-cache-protocol-fn ~gthis ~target ~on-interface ~interf) ~@gargs)))))))
+                  arglists))]
+           (fn [cache#]
          (set! (.__methodImplCache f#) cache#)
          f#))))
 

--- a/src/clj/clojure/core_deftype.clj
+++ b/src/clj/clojure/core_deftype.clj
@@ -574,7 +574,8 @@
   (boolean (find-protocol-impl protocol x)))
 
 (defn -cache-protocol-fn [^clojure.lang.AFunction pf x ^Class c ^clojure.lang.IFn interf]
-  (let [cache  (.__methodImplCache pf)
+  (let [vol (when (volatile? pf) pf)
+        cache  (if vol @vol (.__methodImplCache pf))
         f (if (.isInstance c x)
             interf
             (find-protocol-method (.protocol cache) (.methodk cache) x))]
@@ -582,13 +583,16 @@
             (throw (IllegalArgumentException. (str "No implementation of method: " (.methodk cache) 
                                                    " of protocol: " (:var (.protocol cache)) 
                                              " found for class: " (if (nil? x) "nil" (.getName (class x)))))))
-    (set! (.__methodImplCache pf) (expand-method-impl-cache cache (class x) f))
+    (let [ecache (expand-method-impl-cache cache (class x) f)]
+      (if vol
+        (vreset! vol ecache)
+        (set! (.__methodImplCache pf) ecache)))
     f))
 
 (defn- emit-method-builder [on-interface method on-method arglists extend-via-meta]
   (let [methodk (keyword method)
-        gthis (with-meta (gensym) {:tag 'clojure.lang.AFunction})
-        ginterf (gensym)]
+        gthis (with-meta (gensym (str method "_this__")) {:tag 'clojure.lang.AFunction})
+        ginterf (gensym (str method "_interf__"))]
     `
        (let [~ginterf
              (fn
@@ -607,7 +611,8 @@
                           target (first gargs)]
                       (if extend-via-meta
                         `([~@gargs]
-                            (let [cache# (.__methodImplCache ~gthis)
+                            (let [vol# (.__methodImplCacheVolatile ~gthis)
+                                  cache# @vol#
                                   f# (.fnFor cache# (clojure.lang.Util/classOf ~target))]
                               (if (identical? f# ~ginterf)
                                 (f# ~@gargs)
@@ -615,16 +620,17 @@
                                   (meta# ~@gargs)
                                   (if f#
                                     (f# ~@gargs)
-                                    ((-cache-protocol-fn ~gthis ~target ~on-interface ~ginterf) ~@gargs))))))
+                                    ((-cache-protocol-fn vol# ~target ~on-interface ~ginterf) ~@gargs))))))
                         `([~@gargs]
-                            (let [cache# (.__methodImplCache ~gthis)
+                            (let [vol# (.__methodImplCacheVolatile ~gthis)
+                                  cache# @vol#
                                   f# (.fnFor cache# (clojure.lang.Util/classOf ~target))]
                               (if f#
                                 (f# ~@gargs)
-                                ((-cache-protocol-fn ~gthis ~target ~on-interface ~ginterf) ~@gargs)))))))
+                                ((-cache-protocol-fn vol# ~target ~on-interface ~ginterf) ~@gargs)))))))
                   arglists))]
         (fn [cache#]
-         (set! (.__methodImplCache f#) cache#)
+         (vreset! (.__methodImplCacheVolatile f#) cache#)
          f#))))
 
 (defn -reset-methods [protocol]

--- a/src/clj/clojure/core_deftype.clj
+++ b/src/clj/clojure/core_deftype.clj
@@ -590,8 +590,8 @@
 
 (defn- emit-method-def [on-interface method on-method arglists extend-via-meta]
   (let [methodk (keyword method)
-        ;; extra var indirection per call if not directly linked
-        gthis (with-meta method {:tag 'clojure.lang.AFunction})
+        direct? (:direct-linking *compiler-options*)
+        gthis (with-meta (if direct? method (gensym method)) {:tag 'clojure.lang.AFunction})
         ginterf
             `(fn
                ~@(map 
@@ -602,7 +602,7 @@
                           (. ~(with-meta target {:tag on-interface}) (~(or on-method method) ~@(rest gargs))))))
                   arglists))]
           `(def ~(with-meta method nil)
-             (fn
+             (fn ~@(when-not direct? [gthis])
                ~@(map 
                   (fn [args]
                     (let [gargs (map #(gensym (str "gf__" % "__")) args)

--- a/src/clj/clojure/core_deftype.clj
+++ b/src/clj/clojure/core_deftype.clj
@@ -618,7 +618,7 @@
                                 (f# ~@gargs)
                                 ((-cache-protocol-fn ~gthis ~target ~on-interface ~interf) ~@gargs)))))))
                   arglists))]
-           (fn [cache#]
+        (fn [cache#]
          (set! (.__methodImplCache f#) cache#)
          f#))))
 

--- a/src/clj/clojure/core_deftype.clj
+++ b/src/clj/clojure/core_deftype.clj
@@ -509,21 +509,21 @@
 (defn- expand-method-impl-cache
   ([^clojure.lang.MethodImplCache cache c f] (expand-method-impl-cache cache c f false))
   ([^clojure.lang.MethodImplCache cache c f interface?]
-   (if (.map cache)
-     (let [cs (assoc (.map cache) c (clojure.lang.MethodImplCache$Entry. c f interface?))]
-       (clojure.lang.MethodImplCache. (.sym cache) (.protocol cache) (.methodk cache) cs))
-     (let [cs (into1 {} (remove (fn [[c e]] (nil? e)) (map vec (partition 2 (.table cache)))))
-           cs (assoc cs c (clojure.lang.MethodImplCache$Entry. c f))]
-       (if-let [[shift mask] (maybe-min-hash (map hash (keys cs)))]
-         (let [table (make-array Object (* 2 (inc mask)))
-               table (reduce1 (fn [^objects t [c e]]
-                                (let [i (* 2 (int (shift-mask shift mask (hash c))))]
-                                  (aset t i c)
-                                  (aset t (inc i) e)
-                                  t))
-                              table cs)]
-           (clojure.lang.MethodImplCache. (.sym cache) (.protocol cache) (.methodk cache) shift mask table))
-         (clojure.lang.MethodImplCache. (.sym cache) (.protocol cache) (.methodk cache) cs))))))
+  (if (.map cache)
+    (let [cs (assoc (.map cache) c (clojure.lang.MethodImplCache$Entry. c f interface?))]
+      (clojure.lang.MethodImplCache. (.sym cache) (.protocol cache) (.methodk cache) cs))
+    (let [cs (into1 {} (remove (fn [[c e]] (nil? e)) (map vec (partition 2 (.table cache)))))
+          cs (assoc cs c (clojure.lang.MethodImplCache$Entry. c f))]
+      (if-let [[shift mask] (maybe-min-hash (map hash (keys cs)))]
+        (let [table (make-array Object (* 2 (inc mask)))
+              table (reduce1 (fn [^objects t [c e]]
+                               (let [i (* 2 (int (shift-mask shift mask (hash c))))]
+                                 (aset t i c)
+                                 (aset t (inc i) e)
+                                 t))
+                             table cs)]
+          (clojure.lang.MethodImplCache. (.sym cache) (.protocol cache) (.methodk cache) shift mask table))
+        (clojure.lang.MethodImplCache. (.sym cache) (.protocol cache) (.methodk cache) cs))))))
 
 (defn- super-chain [^Class c]
   (when c

--- a/src/jvm/clojure/lang/AFunction.java
+++ b/src/jvm/clojure/lang/AFunction.java
@@ -20,6 +20,7 @@ public abstract class AFunction extends AFn implements IObj, Comparator, Fn, Ser
 private static final long serialVersionUID = 4469383498184457675L;
 
 public volatile MethodImplCache __methodImplCache;
+public volatile Volatile __methodImplCacheVolatile = new Volatile(null);
 
 public IPersistentMap meta(){
 	return null;

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -3562,7 +3562,7 @@ static class StaticInvokeExpr implements Expr, MaybePrimitiveExpr{
 		java.lang.reflect.Method method = null;
 		for(java.lang.reflect.Method m : allmethods)
 			{
-			System.out.println("StaticInvokeExpr parse: var="+v+" method="+m);
+			//System.out.println(m);
 			if(Modifier.isStatic(m.getModifiers()) && m.getName().equals("invokeStatic"))
 				{
 				Class[] params = m.getParameterTypes();
@@ -3842,10 +3842,10 @@ static class InvokeExpr implements Expr{
                         .parse(v, RT.next(form), formtag != null ? formtag : sigtag != null ? sigtag : vtag, tailPosition);
                 if(ret != null)
                     {
-				    System.out.println("invoke direct: " + v);
+//				    System.out.println("invoke direct: " + v);
                     return ret;
                     }
-                System.out.println("NOT direct: " + v);
+//                System.out.println("NOT direct: " + v);
                 }
 			}
 
@@ -4050,6 +4050,7 @@ static public class FnExpr extends ObjExpr{
 				}
 
 			fn.canBeDirect = !fn.hasEnclosingMethod && fn.closes.count() == 0 && !usesThis;
+			//System.err.println("canBeDirect " + fn.name + "has-enclosing-method="+ fn.hasEnclosingMethod + " closes-count="+fn.closes.count()+" usesThis="+usesThis);
 
 			IPersistentCollection methods = null;
 			for(int i = 0; i < methodArray.length; i++)

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -1139,6 +1139,14 @@ static class InstanceFieldExpr extends FieldExpr implements AssignableExpr{
 		this.column = column;
 		this.tag = tag;
 		this.requireField = requireField;
+    // don't treat __methodImplCache lookups on this as a usage of this
+    if(field != null && field.getDeclaringClass() == AFunction.class && target instanceof LocalBindingExpr)
+    {
+      LocalBinding b = ((LocalBindingExpr)target).b;
+      ObjMethod method = (ObjMethod) METHOD.deref();
+      if(b.idx == 0)
+        method.decThisUsage();
+    }
 		if(field == null && RT.booleanCast(RT.WARN_ON_REFLECTION.deref()))
 			{
 			if(targetClass == null)
@@ -4078,6 +4086,8 @@ static public class FnExpr extends ObjExpr{
 				}
 
 			fn.canBeDirect = !fn.hasEnclosingMethod && fn.closesDirectLinkable() && !usesThis;
+			System.err.println(fn.name+" canBeDirect: fn.hasEnclosingMethod="+fn.hasEnclosingMethod+" fn.closesDirectLinkable()="+fn.closesDirectLinkable()
+          +" usesThis="+usesThis);
 
 			IPersistentCollection methods = null;
 			for(int i = 0; i < methodArray.length; i++)

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -5839,7 +5839,7 @@ abstract public static class ObjMethod{
   }
 
   final boolean usesThis() {
-    return thisUsages == 0;
+    return thisUsages != 0;
   }
 
 	public final IPersistentMap locals(){

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -3562,7 +3562,7 @@ static class StaticInvokeExpr implements Expr, MaybePrimitiveExpr{
 		java.lang.reflect.Method method = null;
 		for(java.lang.reflect.Method m : allmethods)
 			{
-			//System.out.println(m);
+			System.out.println("StaticInvokeExpr parse: var="+v+" method="+m);
 			if(Modifier.isStatic(m.getModifiers()) && m.getName().equals("invokeStatic"))
 				{
 				Class[] params = m.getParameterTypes();
@@ -3842,10 +3842,10 @@ static class InvokeExpr implements Expr{
                         .parse(v, RT.next(form), formtag != null ? formtag : sigtag != null ? sigtag : vtag, tailPosition);
                 if(ret != null)
                     {
-//				    System.out.println("invoke direct: " + v);
+				    System.out.println("invoke direct: " + v);
                     return ret;
                     }
-//                System.out.println("NOT direct: " + v);
+                System.out.println("NOT direct: " + v);
                 }
 			}
 

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -3750,17 +3750,15 @@ static class InvokeExpr implements Expr{
 		gen.putStatic(objx.objtype, objx.cachedClassName(siteIndex),CLASS_TYPE); //target
 
 		gen.mark(callLabel); //target
-    if(directLinkExpr != null)
+		if(directLinkExpr != null)
 			{
-    // TODO direct link
-    //FIXME I have no idea what I'm doing
-        System.out.println("protocol direct: " + v);
-			emitArgs(1, context,objx,gen); //target, args...
-      gen.invokeStatic(directLinkExpr.target, new Method("invokeStatic", directLinkExpr.getReturnType(), directLinkExpr.paramtypes)); //return
+		System.out.println("protocol direct: " + v);
+		emitArgs(1, context,objx,gen); //target, args...
+		gen.invokeStatic(directLinkExpr.target, new Method("invokeStatic", directLinkExpr.getReturnType(), directLinkExpr.paramtypes)); //return
 			}
-    else
+		else
 			{
-        System.out.println("protocol NOT direct: " + v);
+		System.out.println("protocol NOT direct: " + v);
 		objx.emitVar(gen, v);
 		gen.invokeVirtual(VAR_TYPE, Method.getMethod("Object getRawRoot()")); //target, proto-fn
 		gen.swap();
@@ -3809,9 +3807,8 @@ static class InvokeExpr implements Expr{
 			}
 	}
 
-
 	void emitArgsAndCall(int firstArgToEmit, C context, ObjExpr objx, GeneratorAdapter gen){
-    emitArgs(firstArgToEmit, context, objx, gen);
+		emitArgs(firstArgToEmit, context, objx, gen);
 
 		gen.invokeInterface(IFN_TYPE, new Method("invoke", OBJECT_TYPE, ARG_TYPES[Math.min(MAX_POSITIONAL_ARITY + 1,
 		                                                                                   args.count())]));
@@ -3845,7 +3842,7 @@ static class InvokeExpr implements Expr{
 				}
 			}
 
-    StaticInvokeExpr directLinkExpr = null;
+		StaticInvokeExpr directLinkExpr = null;
 		if(RT.booleanCast(getCompilerOption(directLinkingKey))
            && fexpr instanceof VarExpr
            && context != C.EVAL)
@@ -3864,13 +3861,13 @@ static class InvokeExpr implements Expr{
                     {
                     if((Var)RT.get(v.meta(), protocolKey) == null)
                       {
-				    System.out.println("invoke direct: " + v);
+				            System.out.println("invoke direct: " + v);
                     return ret;
                       }
                     else
                       {
-				    System.out.println("invoke protocol direct: " + v);
-                      directLinkExpr = (StaticInvokeExpr)ret;
+				            System.out.println("invoke protocol direct: " + v);
+                    directLinkExpr = (StaticInvokeExpr)ret;
                       }
                     }
                 else

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -3637,7 +3637,7 @@ static class InvokeExpr implements Expr{
         return null;
         }
 
-	public InvokeExpr(String source, int line, int column, Symbol tag, Expr fexpr, IPersistentVector args, boolean tailPosition, Expr directLinkExpr) {
+	public InvokeExpr(String source, int line, int column, Symbol tag, Expr fexpr, IPersistentVector args, boolean tailPosition, StaticInvokeExpr directLinkExpr) {
 		this.source = source;
 		this.fexpr = fexpr;
 		this.args = args;
@@ -3750,10 +3750,11 @@ static class InvokeExpr implements Expr{
 		gen.putStatic(objx.objtype, objx.cachedClassName(siteIndex),CLASS_TYPE); //target
 
 		gen.mark(callLabel); //target
-    if(false //directLinkExpr != null
-        )
+    if(directLinkExpr != null)
 			{
     // TODO direct link
+    //FIXME I have no idea what I'm doing
+      directLinkExpr.emit(context, objx, gen);
 			}
     else
 			{
@@ -3836,7 +3837,7 @@ static class InvokeExpr implements Expr{
 				}
 			}
 
-    Expr directLinkExpr = null;
+    StaticInvokeExpr directLinkExpr = null;
 		if(RT.booleanCast(getCompilerOption(directLinkingKey))
            && fexpr instanceof VarExpr
            && context != C.EVAL)
@@ -3859,7 +3860,7 @@ static class InvokeExpr implements Expr{
                 if(ret != null)
                     {
 //				    System.out.println("invoke protocol direct: " + v);
-                    directLinkExpr = ret;
+                    directLinkExpr = (StaticInvokeExpr)ret;
                     }
 //                System.out.println("NOT direct: " + v);
                 }
@@ -3902,7 +3903,7 @@ static class InvokeExpr implements Expr{
 //			throw new IllegalArgumentException(
 //					String.format("No more than %d args supported", MAX_POSITIONAL_ARITY));
 
-		return new InvokeExpr((String) SOURCE.deref(), lineDeref(), columnDeref(), tagOf(form), fexpr, args, tailPosition);
+		return new InvokeExpr((String) SOURCE.deref(), lineDeref(), columnDeref(), tagOf(form), fexpr, args, tailPosition, directLinkExpr);
 	}
 }
 

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -4050,7 +4050,6 @@ static public class FnExpr extends ObjExpr{
 				}
 
 			fn.canBeDirect = !fn.hasEnclosingMethod && fn.closes.count() == 0 && !usesThis;
-			//System.err.println("canBeDirect " + fn.name + "has-enclosing-method="+ fn.hasEnclosingMethod + " closes-count="+fn.closes.count()+" usesThis="+usesThis);
 
 			IPersistentCollection methods = null;
 			for(int i = 0; i < methodArray.length; i++)

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -3750,13 +3750,13 @@ static class InvokeExpr implements Expr{
 		gen.putStatic(objx.objtype, objx.cachedClassName(siteIndex),CLASS_TYPE); //target
 
 		gen.mark(callLabel); //target
-		if(directLinkExpr != null)
+			if(directLinkExpr != null)
 			{
 		System.out.println("protocol direct: " + v);
 		emitArgs(1, context,objx,gen); //target, args...
 		gen.invokeStatic(directLinkExpr.target, new Method("invokeStatic", directLinkExpr.getReturnType(), directLinkExpr.paramtypes)); //return
 			}
-		else
+			else
 			{
 		System.out.println("protocol NOT direct: " + v);
 		objx.emitVar(gen, v);

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -3749,6 +3749,7 @@ static class InvokeExpr implements Expr{
 
 		gen.mark(callLabel); //target
 		objx.emitVar(gen, v);
+    // TODO direct link
 		gen.invokeVirtual(VAR_TYPE, Method.getMethod("Object getRawRoot()")); //target, proto-fn
 		gen.swap();
 		emitArgsAndCall(1, context,objx,gen);
@@ -3831,11 +3832,7 @@ static class InvokeExpr implements Expr{
            && context != C.EVAL)
 			{
 			Var v = ((VarExpr)fexpr).var;
-			Var pvar =  (Var)RT.get(v.meta(), protocolKey);
-      Object pon = pvar == null ? null : RT.get(pvar.get(), onKey);
-            if(!v.isDynamic() && !RT.booleanCast(RT.get(v.meta(), redefKey, false))
-                // prefer onMethod call over direct linking
-                && !(pvar != null && PROTOCOL_CALLSITES.isBound() && HostExpr.maybeClass(pon,false) != null))
+            if(!v.isDynamic() && !RT.booleanCast(RT.get(v.meta(), redefKey, false)) && (Var)RT.get(v.meta(), protocolKey) == null)
                 {
                 Symbol formtag = tagOf(form);
                 Object arglists = RT.get(RT.meta(v), arglistsKey);

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -3750,9 +3750,7 @@ static class InvokeExpr implements Expr{
 		gen.putStatic(objx.objtype, objx.cachedClassName(siteIndex),CLASS_TYPE); //target
 
 		gen.mark(callLabel); //target
-			if(false //FIXME
-          //directLinkExpr != null
-          )
+			if(directLinkExpr != null)
 			{
 		System.out.println("protocol direct: " + v);
 		emitArgs(1, context,objx,gen); //target, args...
@@ -4250,19 +4248,18 @@ static public class ObjExpr implements Expr{
 	}
 
   public final boolean closesDirectLinkable() {
-    return closes.count() == 0;
-    //if(closes.count() == 0) {
-    //  return true;
-    //} else {
-    //  for(ISeq s = RT.keys(closes); s != null; s = s.next()) {
-    //    LocalBinding lb = (LocalBinding) s.first();
-    //    Expr init = lb.init;
-    //    if (init == null || !(init instanceof ObjExpr) || !((ObjExpr)init).canBeDirect) {
-    //      return false;
-    //    }
-    //  }
-    //  return true;
-    //}
+    if(closes.count() == 0) {
+      return true;
+    } else {
+      for(ISeq s = RT.keys(closes); s != null; s = s.next()) {
+        LocalBinding lb = (LocalBinding) s.first();
+        Expr init = lb.init;
+        if (init == null || !(init instanceof ObjExpr) || !((ObjExpr)init).canBeDirect) {
+          return false;
+        }
+      }
+      return true;
+    }
   }
 
 	public final IPersistentMap keywords(){

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -3613,7 +3613,7 @@ static class InvokeExpr implements Expr{
 	public final int line;
 	public final int column;
 	public final boolean tailPosition;
-  public final StaticInvokeExpr directLinkExpr;
+	public final StaticInvokeExpr directLinkExpr;
 	public final String source;
 	public boolean isProtocol = false;
 	public boolean isDirect = false;

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -3644,7 +3644,7 @@ static class InvokeExpr implements Expr{
 		this.line = line;
 		this.column = column;
 		this.tailPosition = tailPosition;
-    this.directLinkExpr = directLinkExpr;
+		this.directLinkExpr = directLinkExpr;
 
 		if(fexpr instanceof VarExpr)
 			{

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -3861,18 +3861,18 @@ static class InvokeExpr implements Expr{
                     {
                     if((Var)RT.get(v.meta(), protocolKey) == null)
                       {
-				            System.out.println("invoke direct: " + v);
+//				    System.out.println("invoke direct: " + v);
                     return ret;
                       }
                     else
                       {
-				            System.out.println("invoke protocol direct: " + v);
+//				    System.out.println("invoke protocol direct: " + v);
                     directLinkExpr = (StaticInvokeExpr)ret;
                       }
                     }
                 else
                   {
-                System.out.println("NOT direct: " + v);
+//                System.out.println("NOT direct: " + v);
                   }
                 }
 			}

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -3831,7 +3831,11 @@ static class InvokeExpr implements Expr{
            && context != C.EVAL)
 			{
 			Var v = ((VarExpr)fexpr).var;
-            if(!v.isDynamic() && !RT.booleanCast(RT.get(v.meta(), redefKey, false)))
+			Var pvar =  (Var)RT.get(v.meta(), protocolKey);
+      Object pon = pvar == null ? null : RT.get(pvar.get(), onKey);
+            if(!v.isDynamic() && !RT.booleanCast(RT.get(v.meta(), redefKey, false))
+                // prefer onMethod call over direct linking
+                && !(pvar != null && PROTOCOL_CALLSITES.isBound() && HostExpr.maybeClass(pon,false) != null))
                 {
                 Symbol formtag = tagOf(form);
                 Object arglists = RT.get(RT.meta(v), arglistsKey);

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -3754,11 +3754,13 @@ static class InvokeExpr implements Expr{
 			{
     // TODO direct link
     //FIXME I have no idea what I'm doing
+        System.out.println("protocol direct: " + v);
 			emitArgs(1, context,objx,gen); //target, args...
       gen.invokeStatic(directLinkExpr.target, new Method("invokeStatic", directLinkExpr.getReturnType(), directLinkExpr.paramtypes)); //return
 			}
     else
 			{
+        System.out.println("protocol NOT direct: " + v);
 		objx.emitVar(gen, v);
 		gen.invokeVirtual(VAR_TYPE, Method.getMethod("Object getRawRoot()")); //target, proto-fn
 		gen.swap();
@@ -3862,18 +3864,18 @@ static class InvokeExpr implements Expr{
                     {
                     if((Var)RT.get(v.meta(), protocolKey) == null)
                       {
-//				    System.out.println("invoke direct: " + v);
+				    System.out.println("invoke direct: " + v);
                     return ret;
                       }
                     else
                       {
-//				    System.out.println("invoke protocol direct: " + v);
+				    System.out.println("invoke protocol direct: " + v);
                       directLinkExpr = (StaticInvokeExpr)ret;
                       }
                     }
                 else
                   {
-//                System.out.println("NOT direct: " + v);
+                System.out.println("NOT direct: " + v);
                   }
                 }
 			}

--- a/src/jvm/clojure/lang/MethodImplCache.java
+++ b/src/jvm/clojure/lang/MethodImplCache.java
@@ -78,7 +78,7 @@ public MethodImplCache(Symbol sym, IPersistentMap protocol, Keyword methodk, Map
 
 public IFn fnFor(Class c){
 	Entry e = fnEntryFor(c);
-	return e != null ? e.fn : null;
+	return  e != null ? e.fn : null;
 }
 
 public Entry fnEntryFor(Class c){

--- a/src/jvm/clojure/lang/MethodImplCache.java
+++ b/src/jvm/clojure/lang/MethodImplCache.java
@@ -19,27 +19,27 @@ public final class MethodImplCache{
 static public class Entry{
 	final public Class c;
 	final public IFn fn;
-  // private in case we need richer distinctions in the future.
-  // could also use an enum here.
-  final private boolean _isInterface;
+	// private in case we need richer distinctions in the future.
+	// could also use an enum here.
+	final private boolean _isInterface;
 
 	public Entry(Class c, IFn fn){
 		this.c = c;
 		this.fn = fn;
-    // any code that calls this constructor will not use isInterface()
-    // as it was compiled using an older Clojure runtime.
-    this._isInterface = false;
+		// any code that calls this constructor will not use isInterface()
+		// as it was compiled using an older Clojure runtime.
+		this._isInterface = false;
 	}
 
 	public Entry(Class c, IFn fn, boolean isInterface){
 		this.c = c;
 		this.fn = fn;
-    this._isInterface = isInterface;
+		this._isInterface = isInterface;
 	}
 
-  public boolean isInterface() {
-    return _isInterface;
-  }
+	public boolean isInterface() {
+		return _isInterface;
+	}
 }
 
 public final IPersistentMap protocol;
@@ -76,6 +76,11 @@ public MethodImplCache(Symbol sym, IPersistentMap protocol, Keyword methodk, Map
     this.map = map;
 }
 
+public IFn fnFor(Class c){
+	Entry e = fnEntryFor(c);
+  return e != null ? e.fn : null;
+}
+
 public Entry fnEntryFor(Class c){
 	Entry last = mre;
 	if(last != null && last.c == c)
@@ -83,17 +88,12 @@ public Entry fnEntryFor(Class c){
 	return findFnEntryFor(c);
 }
 
-public IFn fnFor(Class c){
-	Entry e = fnEntryFor(c);
-  return e != null ? e.fn : null;
-}
-
 Entry findFnEntryFor(Class c){
     if (map != null)
         {
         Entry e = (Entry) map.get(c);
         mre = e;
-        return e;
+        return  e;
         }
     else
         {
@@ -102,10 +102,11 @@ Entry findFnEntryFor(Class c){
             {
             Entry e = ((Entry) table[idx + 1]);
             mre = e;
-            return e;
+            return  e;
             }
         return null;
         }
 }
+
 
 }

--- a/src/jvm/clojure/lang/MethodImplCache.java
+++ b/src/jvm/clojure/lang/MethodImplCache.java
@@ -19,11 +19,27 @@ public final class MethodImplCache{
 static public class Entry{
 	final public Class c;
 	final public IFn fn;
+  // private in case we need richer distinctions in the future.
+  // could also use an enum here.
+  final private boolean _isInterface;
 
 	public Entry(Class c, IFn fn){
 		this.c = c;
 		this.fn = fn;
+    // any code that calls this constructor will not use isInterface()
+    // as it was compiled using an older Clojure runtime.
+    this._isInterface = false;
 	}
+
+	public Entry(Class c, IFn fn, boolean isInterface){
+		this.c = c;
+		this.fn = fn;
+    this._isInterface = isInterface;
+	}
+
+  public boolean isInterface() {
+    return _isInterface;
+  }
 }
 
 public final IPersistentMap protocol;
@@ -60,19 +76,24 @@ public MethodImplCache(Symbol sym, IPersistentMap protocol, Keyword methodk, Map
     this.map = map;
 }
 
-public IFn fnFor(Class c){
+public Entry fnEntryFor(Class c){
 	Entry last = mre;
 	if(last != null && last.c == c)
-		return last.fn;
-	return findFnFor(c);
+		return last;
+	return findFnEntryFor(c);
 }
 
-IFn findFnFor(Class c){
+public IFn fnFor(Class c){
+	Entry e = fnEntryFor(c);
+  return e != null ? e.fn : null;
+}
+
+Entry findFnEntryFor(Class c){
     if (map != null)
         {
         Entry e = (Entry) map.get(c);
         mre = e;
-        return  e != null ? e.fn : null;
+        return e;
         }
     else
         {
@@ -81,11 +102,10 @@ IFn findFnFor(Class c){
             {
             Entry e = ((Entry) table[idx + 1]);
             mre = e;
-            return  e != null ? e.fn : null;
+            return e;
             }
         return null;
         }
 }
-
 
 }

--- a/src/jvm/clojure/lang/MethodImplCache.java
+++ b/src/jvm/clojure/lang/MethodImplCache.java
@@ -78,7 +78,7 @@ public MethodImplCache(Symbol sym, IPersistentMap protocol, Keyword methodk, Map
 
 public IFn fnFor(Class c){
 	Entry e = fnEntryFor(c);
-  return e != null ? e.fn : null;
+	return e != null ? e.fn : null;
 }
 
 public Entry fnEntryFor(Class c){

--- a/src/jvm/clojure/lang/MethodImplCache.java
+++ b/src/jvm/clojure/lang/MethodImplCache.java
@@ -19,26 +19,10 @@ public final class MethodImplCache{
 static public class Entry{
 	final public Class c;
 	final public IFn fn;
-	// private in case we need richer distinctions in the future.
-	// could also use an enum here.
-	final private boolean _isInterface;
 
 	public Entry(Class c, IFn fn){
 		this.c = c;
 		this.fn = fn;
-		// any code that calls this constructor will not use isInterface()
-		// as it was compiled using an older Clojure runtime.
-		this._isInterface = false;
-	}
-
-	public Entry(Class c, IFn fn, boolean isInterface){
-		this.c = c;
-		this.fn = fn;
-		this._isInterface = isInterface;
-	}
-
-	public boolean isInterface() {
-		return _isInterface;
 	}
 }
 
@@ -77,23 +61,18 @@ public MethodImplCache(Symbol sym, IPersistentMap protocol, Keyword methodk, Map
 }
 
 public IFn fnFor(Class c){
-	Entry e = fnEntryFor(c);
-	return  e != null ? e.fn : null;
-}
-
-public Entry fnEntryFor(Class c){
 	Entry last = mre;
 	if(last != null && last.c == c)
-		return last;
-	return findFnEntryFor(c);
+		return last.fn;
+	return findFnFor(c);
 }
 
-Entry findFnEntryFor(Class c){
+IFn findFnFor(Class c){
     if (map != null)
         {
         Entry e = (Entry) map.get(c);
         mre = e;
-        return  e;
+        return  e != null ? e.fn : null;
         }
     else
         {
@@ -102,7 +81,7 @@ Entry findFnEntryFor(Class c){
             {
             Entry e = ((Entry) table[idx + 1]);
             mre = e;
-            return  e;
+            return  e != null ? e.fn : null;
             }
         return null;
         }


### PR DESCRIPTION
Is the emitArgs call still appropriate for invokeStatic?

This is broken, I think because of https://clojure.atlassian.net/browse/CLJ-1865 the recursive calls needed for a protocol to lookup its own cache are not directly linked. Can we stash the cache somewhere else?

```
(defprotocol Foo (pfoo [this]))
(defn libfn [x] (pfoo x))
(extend-protocol Foo String (pfoo [_] :dude))
(libfn "hello")
(alter-var-root #'user/pfoo (fn [old] (fn [this] (prn :this) (old this))))
(libfn "hello")
Execution error (NullPointerException) at user/pfoo (REPL:1).
Cannot invoke "clojure.lang.MethodImplCache.fnFor(java.lang.Class)" because "cache__8012__auto__2146" is null
```

Idea: start from scratch, this time try and broaden the Fn's that canBeDirect. For protocols, we need to:
1. allow `(.__methodImplCache this)` without counting towards "this" usages, and
2. allow functions to close over other directly linkable functions.