### PR TITLE
reproducible jar 1.12.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,4 @@ jobs:
         cache: 'maven'
     - name: Build with Maven
       run: mvn -ntp -B -P${{ matrix.profile }} clean test
+    - run: ./verify-reproducible.sh

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 
   <properties>
     <directlinking>true</directlinking>
+    <project.build.outputTimestamp>2023-01-01T00:00:00Z</project.build.outputTimestamp>
   </properties>
 
   <dependencies>

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -8120,7 +8120,7 @@ static void closeOver(LocalBinding b, ObjMethod method){
 			else
 				{
 				// reconstruct array map to preserve order
-				Object[] closesvec = new Object[2 + newCloses.count()*2];
+				Object[] closesvec = new Object[2 + oldCloses.count()*2];
 				int i=0;
 				for(ISeq s = RT.seq(oldCloses);s!=null;s = s.next())
 					{

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -4737,7 +4737,7 @@ static public class ObjExpr implements Expr{
 	Type objtype;
 	public final Object tag;
 	//localbinding->itself
-	IPersistentMap closes = PersistentHashMap.EMPTY;
+	IPersistentMap closes = PersistentArrayMap.EMPTY;
     //localbndingexprs
     IPersistentVector closesExprs = PersistentVector.EMPTY;
 	//symbols
@@ -8113,6 +8113,7 @@ static void closeOver(LocalBinding b, ObjMethod method){
         LocalBinding lb = (LocalBinding) RT.get(method.locals, b);
 		if(lb == null)
 			{
+			//FIXME preserve PersistentArrayMap
 			method.objx.closes = (IPersistentMap) RT.assoc(method.objx.closes, b, b);
 			closeOver(b, method.parent);
 			}

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -8113,8 +8113,25 @@ static void closeOver(LocalBinding b, ObjMethod method){
         LocalBinding lb = (LocalBinding) RT.get(method.locals, b);
 		if(lb == null)
 			{
-			//FIXME preserve PersistentArrayMap
-			method.objx.closes = (IPersistentMap) RT.assoc(method.objx.closes, b, b);
+			final IPersistentMap oldCloses = method.objx.closes;
+			final IPersistentMap newCloses = (IPersistentMap)RT.assoc(oldCloses, b, b);
+			if(newCloses instanceof PersistentArrayMap)
+				method.objx.closes = newCloses;
+			else
+				{
+				// reconstruct array map to preserve order
+				Object[] closesvec = new Object[2 + newCloses.count()*2];
+				int i=0;
+				for(ISeq s = RT.seq(oldCloses);s!=null;s = s.next())
+					{
+					IMapEntry e = (IMapEntry) s.first();
+					closesvec[i++] = e.key();
+					closesvec[i++] = e.val();
+					}
+				closesvec[i++] = b;
+				closesvec[i++] = b;
+				method.objx.closes = PersistentArrayMap.createAsIfByAssoc(closesvec);
+				}
 			closeOver(b, method.parent);
 			}
 		else {

--- a/verify-reproducible.sh
+++ b/verify-reproducible.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+
+mvn clean install -Dmaven.test.skip=true
+mvn clean verify artifact:compare -Dmaven.test.skip=true


### PR DESCRIPTION
1. Add timestamp to stabilize jar order and timestamps: https://maven.apache.org/guides/mini/guide-reproducible-builds.html
2. Use array map to ensure closed over locals are emitted in order in the compiler. Simply updating the initial value to an array map seems sufficient for making Clojure itself reproducible (I'm guessing it fails sometimes), added extra code to ensure array map is preserved for large closures. Changing the conditional to `if(false)` to force the "reconstruct entire array map" path also seems to work, so I didn't investigate further with larger closures.

How to test reproduciblity: https://maven.apache.org/guides/mini/guide-reproducible-builds.html#how-to-test-my-maven-build-reproducibility

```bash
mvn clean install -Dmaven.test.skip=true
mvn clean verify artifact:compare -Dmaven.test.skip=true
```
