### PR TITLE
Optimize syntax-quote for vectors without splices

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
         distribution: ["temurin", "corretto"]
         profile: ["test-direct", "test-no-direct"]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     steps:
     - uses: actions/checkout@v4
     - name: Set up Java

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,4 @@ jobs:
         cache: 'maven'
     - name: Build with Maven
       run: mvn -ntp -B -P${{ matrix.profile }} clean test
+    - run: ./verify-reproducible.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         distribution: ["temurin"] #, "corretto"]
         profile: ["test-direct"] # , "test-no-direct"]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4
     - name: Set up Java

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,4 @@ jobs:
     - name: Build with Maven
       run: mvn -ntp -B -P${{ matrix.profile }} clean test
     - run: ./verify-reproducible.sh
+    - run: ./compare-optimization.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,4 +28,11 @@ jobs:
     - name: Build with Maven
       run: mvn -ntp -B -P${{ matrix.profile }} clean test
     - run: ./verify-reproducible.sh
+    - run: sudo apt-get update
+    - run: sudo apt-get install diffoscope
     - run: ./compare-optimization.sh
+    - uses: actions/upload-artifact@v7
+      with:
+        name: clojure-1.13.0-syntax-quotedvec.jar.diffoscope
+        path: clojure-1.13.0-syntax-quotedvec.jar.diffoscope
+        if-no-files-found: error

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest] # macOS-latest, windows-latest]
-        java-version: ["8", "11", "17", "21", "25"]
-        distribution: ["temurin", "corretto"]
-        profile: ["test-direct", "test-no-direct"]
+        java-version: ["8"] #, "11", "17", "21", "25"]
+        distribution: ["temurin"] #, "corretto"]
+        profile: ["test-direct"] # , "test-no-direct"]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,4 +36,7 @@ jobs:
       with:
         name: clojure-1.13.0-syntax-quotedvec.jar.diffoscope
         path: clojure-1.13.0-syntax-quotedvec.jar.diffoscope
-        if-no-files-found: error
+    - uses: actions/upload-artifact@v7
+      with:
+        name: clojure-1.13.0-syntax-quotedvec.dir.diffoscope
+        path: clojure-1.13.0-syntax-quotedvec.dir.diffoscope

--- a/build.xml
+++ b/build.xml
@@ -29,6 +29,7 @@
   <property name="clojure_noversion_jar" location="clojure.jar"/>
 
   <property name="directlinking" value="true"/>
+  <property name="optimizeSyntaxQuote" value="false"/>
 
   <target name="init" depends="clean">
     <tstamp/>
@@ -46,6 +47,7 @@
 
   <target name="compile-clojure"
           description="Compile Clojure sources.">
+    <echo>Optimize syntax quote = ${optimizeSyntaxQuote}</echo>
     <java classname="clojure.lang.Compile"
           classpath="${maven.compile.classpath}:${build}:${cljsrc}"
           failonerror="true"
@@ -55,6 +57,7 @@
          <!--<sysproperty key="clojure.compiler.disable-locals-clearing" value="true"/>-->
        <!--<sysproperty key="clojure.compile.warn-on-reflection" value="true"/>-->
         <sysproperty key="clojure.compiler.direct-linking" value="true"/>
+        <sysproperty key="clojure.optimizeSyntaxQuote" value="${optimizeSyntaxQuote}"/>
       <sysproperty key="java.awt.headless" value="true"/>
       <arg value="clojure.core"/>
       <arg value="clojure.core.protocols"/>

--- a/compare-optimization.sh
+++ b/compare-optimization.sh
@@ -2,8 +2,11 @@
 
 set -e
 
-mvn clean install -Dmaven.test.skip=true -DargLine="-Dclojure.disable-splice-optimization=y"
-mvn clean verify artifact:compare -Dmaven.test.skip=true 
+mvn clean install -Dmaven.test.skip=true
+
+set +e
+mvn clean verify artifact:compare -Dmaven.test.skip=true -PoptimizeSyntaxQuote
+set -e
 
 cat target/clojure-1.13.0-syntaxquotedvec.buildcompare
 diffoscope target/reference/org.clojure/clojure-1.13.0-syntaxquotedvec.jar target/clojure-1.13.0-syntaxquotedvec.jar

--- a/compare-optimization.sh
+++ b/compare-optimization.sh
@@ -2,9 +2,9 @@
 
 set -e
 
-mvn --batch-mode clean install -Dmaven.test.skip=true
+mvn --batch-mode --no-transfer-progress clean install -Dmaven.test.skip=true
 # expected to fail
-mvn --batch-mode clean verify artifact:compare -Dmaven.test.skip=true -PoptimizeSyntaxQuote || true
+mvn --batch-mode --no-transfer-progress clean verify artifact:compare -Dmaven.test.skip=true -PoptimizeSyntaxQuote || true
 
 cat target/clojure-1.13.0-syntaxquotedvec.buildcompare
 diffoscope target/reference/org.clojure/clojure-1.13.0-syntaxquotedvec.jar target/clojure-1.13.0-syntaxquotedvec.jar > clojure-1.13.0-syntax-quotedvec.jar.diffoscope

--- a/compare-optimization.sh
+++ b/compare-optimization.sh
@@ -7,6 +7,6 @@ mvn --batch-mode --no-transfer-progress clean install -Dmaven.test.skip=true
 mvn --batch-mode --no-transfer-progress clean verify artifact:compare -Dmaven.test.skip=true -PoptimizeSyntaxQuote || true
 
 cat target/clojure-1.13.0-syntaxquotedvec.buildcompare
-diffoscope target/reference/org.clojure/clojure-1.13.0-syntaxquotedvec.jar target/clojure-1.13.0-syntaxquotedvec.jar > clojure-1.13.0-syntax-quotedvec.jar.diffoscope
+diffoscope target/reference/org.clojure/clojure-1.13.0-syntaxquotedvec.jar target/clojure-1.13.0-syntaxquotedvec.jar || true > clojure-1.13.0-syntax-quotedvec.jar.diffoscope
 
 cat clojure-1.13.0-syntax-quotedvec.jar.diffoscope

--- a/compare-optimization.sh
+++ b/compare-optimization.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+mvn clean install -Dmaven.test.skip=true -DargLine="-Dclojure.disable-splice-optimization=y"
+mvn clean verify artifact:compare -Dmaven.test.skip=true 
+
+cat target/clojure-1.13.0-syntaxquotedvec.buildcompare
+diffoscope target/reference/org.clojure/clojure-1.13.0-syntaxquotedvec.jar target/clojure-1.13.0-syntaxquotedvec.jar

--- a/compare-optimization.sh
+++ b/compare-optimization.sh
@@ -21,19 +21,9 @@ mkdir -p "$REFDIR" "$OPTIMDIR"
 unzip -q target/reference/org.clojure/clojure-1.13.0-syntaxquotedvec.jar -d "$REFDIR"
 unzip -q target/clojure-1.13.0-syntaxquotedvec.jar -d "$OPTIMDIR"
 
-# Disassemble .class files: replace .class files with javap output files (with .java_disasm suffix)
-for DIR in "$REFDIR" "$OPTIMDIR"; do
-  find "$DIR" -name '*.class' -print0 | while IFS= read -r -d '' CLASSFILE; do
-    # compute class name from file path
-    RELPATH="${CLASSFILE#$DIR/}"
-    CLASSNAME="${RELPATH%.class}"
-    CLASSNAME="${CLASSNAME//\//.}"
-    # run javap and write to a .class.disasm file next to original
-    javap -c -p -classpath "$DIR" "$CLASSNAME" > "${CLASSFILE}.disasm" 2>/dev/null || javap -c -classpath "$DIR" "$CLASSNAME" > "${CLASSFILE}.disasm" 2>/dev/null || echo "failed to disassemble $CLASSFILE" > "${CLASSFILE}.disasm"
-    # remove original .class file
-    rm -f "$CLASSFILE"
-  done
-done
+# Disassemble .class files: replace .class files with javap output files (with .class.disasm suffix)
+# Use a small Python helper to handle class-name conversion and robust javap invocation
+python3 "$(dirname "$0")/disassemble_classes.py" "$REFDIR" "$OPTIMDIR"
 
 # Now run diffoscope on the two directories
 diffoscope "$REFDIR" "$OPTIMDIR" > clojure-1.13.0-syntax-quotedvec.dir.diffoscope || true

--- a/compare-optimization.sh
+++ b/compare-optimization.sh
@@ -9,4 +9,6 @@ mvn clean verify artifact:compare -Dmaven.test.skip=true -PoptimizeSyntaxQuote
 set -e
 
 cat target/clojure-1.13.0-syntaxquotedvec.buildcompare
-diffoscope target/reference/org.clojure/clojure-1.13.0-syntaxquotedvec.jar target/clojure-1.13.0-syntaxquotedvec.jar
+diffoscope target/reference/org.clojure/clojure-1.13.0-syntaxquotedvec.jar target/clojure-1.13.0-syntaxquotedvec.jar > clojure-1.13.0-syntax-quotedvec.jar.diffoscope
+
+cat clojure-1.13.0-syntax-quotedvec.jar.diffoscope

--- a/compare-optimization.sh
+++ b/compare-optimization.sh
@@ -7,6 +7,6 @@ mvn --batch-mode --no-transfer-progress clean install -Dmaven.test.skip=true
 mvn --batch-mode --no-transfer-progress clean verify artifact:compare -Dmaven.test.skip=true -PoptimizeSyntaxQuote || true
 
 cat target/clojure-1.13.0-syntaxquotedvec.buildcompare
-diffoscope target/reference/org.clojure/clojure-1.13.0-syntaxquotedvec.jar target/clojure-1.13.0-syntaxquotedvec.jar || true > clojure-1.13.0-syntax-quotedvec.jar.diffoscope
+diffoscope target/reference/org.clojure/clojure-1.13.0-syntaxquotedvec.jar target/clojure-1.13.0-syntaxquotedvec.jar > clojure-1.13.0-syntax-quotedvec.jar.diffoscope || true
 
 cat clojure-1.13.0-syntax-quotedvec.jar.diffoscope

--- a/compare-optimization.sh
+++ b/compare-optimization.sh
@@ -7,6 +7,38 @@ mvn --batch-mode --no-transfer-progress clean install -Dmaven.test.skip=true
 mvn --batch-mode --no-transfer-progress clean verify artifact:compare -Dmaven.test.skip=true -PoptimizeSyntaxQuote || true
 
 cat target/clojure-1.13.0-syntaxquotedvec.buildcompare
-diffoscope target/reference/org.clojure/clojure-1.13.0-syntaxquotedvec.jar target/clojure-1.13.0-syntaxquotedvec.jar > clojure-1.13.0-syntax-quotedvec.jar.diffoscope || true
 
+# Produce diffoscope of the two jars
+diffoscope target/reference/org.clojure/clojure-1.13.0-syntaxquotedvec.jar target/clojure-1.13.0-syntaxquotedvec.jar > clojure-1.13.0-syntax-quotedvec.jar.diffoscope || true
 cat clojure-1.13.0-syntax-quotedvec.jar.diffoscope
+
+# Also produce a more detailed diff by unzipping, disassembling .class files with javap, and comparing directories
+TMPDIR=$(mktemp -d)
+REFDIR="$TMPDIR/ref"
+OPTIMDIR="$TMPDIR/opt"
+mkdir -p "$REFDIR" "$OPTIMDIR"
+
+unzip -q target/reference/org.clojure/clojure-1.13.0-syntaxquotedvec.jar -d "$REFDIR"
+unzip -q target/clojure-1.13.0-syntaxquotedvec.jar -d "$OPTIMDIR"
+
+# Disassemble .class files: replace .class files with javap output files (with .java_disasm suffix)
+for DIR in "$REFDIR" "$OPTIMDIR"; do
+  find "$DIR" -name '*.class' -print0 | while IFS= read -r -d '' CLASSFILE; do
+    # compute class name from file path
+    RELPATH="${CLASSFILE#$DIR/}"
+    CLASSNAME="${RELPATH%.class}"
+    CLASSNAME="${CLASSNAME//\//.}"
+    # run javap and write to a .class.disasm file next to original
+    javap -c -p -classpath "$DIR" "$CLASSNAME" > "${CLASSFILE}.disasm" 2>/dev/null || javap -c -classpath "$DIR" "$CLASSNAME" > "${CLASSFILE}.disasm" 2>/dev/null || echo "failed to disassemble $CLASSFILE" > "${CLASSFILE}.disasm"
+    # remove original .class file
+    rm -f "$CLASSFILE"
+  done
+done
+
+# Now run diffoscope on the two directories
+diffoscope "$REFDIR" "$OPTIMDIR" > clojure-1.13.0-syntax-quotedvec.dir.diffoscope || true
+cat clojure-1.13.0-syntax-quotedvec.dir.diffoscope
+
+# cleanup
+# keep TMPDIR for artifact upload; do not remove immediately so GitHub Actions can access files
+echo "Detailed disassembly diff at: $TMPDIR"

--- a/compare-optimization.sh
+++ b/compare-optimization.sh
@@ -2,11 +2,9 @@
 
 set -e
 
-mvn clean install -Dmaven.test.skip=true
-
-set +e
-mvn clean verify artifact:compare -Dmaven.test.skip=true -PoptimizeSyntaxQuote
-set -e
+mvn --batch-mode clean install -Dmaven.test.skip=true
+# expected to fail
+mvn --batch-mode clean verify artifact:compare -Dmaven.test.skip=true -PoptimizeSyntaxQuote || true
 
 cat target/clojure-1.13.0-syntaxquotedvec.buildcompare
 diffoscope target/reference/org.clojure/clojure-1.13.0-syntaxquotedvec.jar target/clojure-1.13.0-syntaxquotedvec.jar > clojure-1.13.0-syntax-quotedvec.jar.diffoscope

--- a/disassemble_classes.py
+++ b/disassemble_classes.py
@@ -1,64 +1,102 @@
 #!/usr/bin/env python3
-"""Disassemble all .class files under a directory using javap.
-Replaces each .class file with a .class.disasm file containing javap -c -p output.
-Exits non-zero only on unexpected errors; per-file failures are recorded in the .disasm file.
+"""Disassemble .class files that differ between two directories using javap.
+Usage: disassemble_classes.py <dir1> <dir2>
+For any relative .class path that either exists in only one dir or whose contents differ,
+write a .class.disasm file next to each existing .class and remove the original .class.
 """
-import os
 import sys
 import subprocess
 from pathlib import Path
+import hashlib
 
 
-def disassemble_dir(root_dir: Path) -> int:
-    root_dir = root_dir.resolve()
-    if not root_dir.is_dir():
-        print(f"Not a directory: {root_dir}", file=sys.stderr)
-        return 2
-    for dirpath, _, filenames in os.walk(root_dir):
-        for fn in filenames:
-            if not fn.endswith('.class'):
-                continue
-            classfile = Path(dirpath) / fn
-            # compute class name relative to root_dir, convert path sep -> dot and strip .class
-            rel = classfile.relative_to(root_dir)
-            classname = str(rel.with_suffix('')).replace(os.sep, '.')
-            outpath = classfile.with_suffix(classfile.suffix + '.disasm')
-            # run javap
-            try:
-                # first try with class name
-                proc = subprocess.run(['javap', '-c', '-p', '-classpath', str(root_dir), classname],
-                                      stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False)
-                out = proc.stdout
-                if proc.returncode != 0:
-                    # fallback: try javap on the file path
-                    proc2 = subprocess.run(['javap', '-c', '-p', str(classfile)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False)
-                    out = proc2.stdout
-                if not out:
-                    out = f"failed to disassemble {classfile}\n"
-            except FileNotFoundError:
-                out = "javap not found in PATH\n"
-            try:
-                outpath.write_text(out)
-            except Exception as e:
-                print(f"Failed to write disasm for {classfile}: {e}", file=sys.stderr)
-                return 3
-            try:
-                classfile.unlink()
-            except Exception as e:
-                print(f"Failed to remove class file {classfile}: {e}", file=sys.stderr)
+def sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open('rb') as f:
+        for chunk in iter(lambda: f.read(8192), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def collect_class_paths(dirpath: Path):
+    result = set()
+    for p in dirpath.rglob('*.class'):
+        result.add(p.relative_to(dirpath))
+    return result
+
+
+def disassemble_file(root_dir: Path, classfile_rel: Path) -> int:
+    classfile = (root_dir / classfile_rel).resolve()
+    outpath = classfile.with_suffix(classfile.suffix + '.disasm')
+    # classname: replace path sep with dot and strip .class
+    classname = str(classfile_rel.with_suffix('')).replace('/', '.').replace('\\', '.')
+    try:
+        print(f"Disassembling {classname}")
+        proc = subprocess.run(['javap', '-c', '-p', '-classpath', str(root_dir), classname],
+                              stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False)
+        out = proc.stdout
+        if proc.returncode != 0 or not out:
+            proc2 = subprocess.run(['javap', '-c', '-p', str(classfile)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False)
+            out = proc2.stdout
+        if not out:
+            out = f"failed to disassemble {classfile}\n"
+    except FileNotFoundError:
+        out = "javap not found in PATH\n"
+    try:
+        outpath.write_text(out)
+    except Exception as e:
+        print(f"Failed to write disasm for {classfile}: {e}", file=sys.stderr)
+        return 3
+    try:
+        classfile.unlink()
+    except Exception as e:
+        print(f"Failed to remove class file {classfile}: {e}", file=sys.stderr)
     return 0
 
 
 def main():
-    if len(sys.argv) < 2:
-        print("Usage: disassemble_classes.py <dir> [<dir> ...]", file=sys.stderr)
+    if len(sys.argv) != 3:
+        print("Usage: disassemble_classes.py <dir1> <dir2>", file=sys.stderr)
         sys.exit(2)
-    rc = 0
-    for d in sys.argv[1:]:
-        r = disassemble_dir(Path(d))
-        if r != 0:
-            rc = r
-    sys.exit(rc)
+    dir1 = Path(sys.argv[1]).resolve()
+    dir2 = Path(sys.argv[2]).resolve()
+    if not dir1.is_dir() or not dir2.is_dir():
+        print("Both arguments must be directories", file=sys.stderr)
+        sys.exit(2)
+
+    paths1 = collect_class_paths(dir1)
+    paths2 = collect_class_paths(dir2)
+    all_paths = paths1.union(paths2)
+
+    exit_code = 0
+    for rel in sorted(all_paths):
+        p1 = dir1 / rel
+        p2 = dir2 / rel
+        exists1 = p1.exists()
+        exists2 = p2.exists()
+        need = False
+        if exists1 and exists2:
+            try:
+                if sha256(p1) != sha256(p2):
+                    need = True
+            except Exception as e:
+                print(f"Failed hashing files {p1} or {p2}: {e}", file=sys.stderr)
+                need = True
+        else:
+            # present only in one dir
+            need = True
+        if not need:
+            continue
+        # disassemble whichever exists
+        if exists1:
+            r = disassemble_file(dir1, rel)
+            if r != 0:
+                exit_code = r
+        if exists2:
+            r = disassemble_file(dir2, rel)
+            if r != 0:
+                exit_code = r
+    sys.exit(exit_code)
 
 
 if __name__ == '__main__':

--- a/disassemble_classes.py
+++ b/disassemble_classes.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Disassemble all .class files under a directory using javap.
+Replaces each .class file with a .class.disasm file containing javap -c -p output.
+Exits non-zero only on unexpected errors; per-file failures are recorded in the .disasm file.
+"""
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+
+def disassemble_dir(root_dir: Path) -> int:
+    root_dir = root_dir.resolve()
+    if not root_dir.is_dir():
+        print(f"Not a directory: {root_dir}", file=sys.stderr)
+        return 2
+    for dirpath, _, filenames in os.walk(root_dir):
+        for fn in filenames:
+            if not fn.endswith('.class'):
+                continue
+            classfile = Path(dirpath) / fn
+            # compute class name relative to root_dir, convert path sep -> dot and strip .class
+            rel = classfile.relative_to(root_dir)
+            classname = str(rel.with_suffix('')).replace(os.sep, '.')
+            outpath = classfile.with_suffix(classfile.suffix + '.disasm')
+            # run javap
+            try:
+                # first try with class name
+                proc = subprocess.run(['javap', '-c', '-p', '-classpath', str(root_dir), classname],
+                                      stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False)
+                out = proc.stdout
+                if proc.returncode != 0:
+                    # fallback: try javap on the file path
+                    proc2 = subprocess.run(['javap', '-c', '-p', str(classfile)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False)
+                    out = proc2.stdout
+                if not out:
+                    out = f"failed to disassemble {classfile}\n"
+            except FileNotFoundError:
+                out = "javap not found in PATH\n"
+            try:
+                outpath.write_text(out)
+            except Exception as e:
+                print(f"Failed to write disasm for {classfile}: {e}", file=sys.stderr)
+                return 3
+            try:
+                classfile.unlink()
+            except Exception as e:
+                print(f"Failed to remove class file {classfile}: {e}", file=sys.stderr)
+    return 0
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: disassemble_classes.py <dir> [<dir> ...]", file=sys.stderr)
+        sys.exit(2)
+    rc = 0
+    for d in sys.argv[1:]:
+        r = disassemble_dir(Path(d))
+        if r != 0:
+            rc = r
+    sys.exit(rc)
+
+
+if __name__ == '__main__':
+    main()

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <directlinking>true</directlinking>
     <optimizeSyntaxQuote>false</optimizeSyntaxQuote>
     <!-- just for reproducibility, not part of syntax-quote optimization -->
-    <project.build.outputTimeStamp>2026-01-01T00:00:00Z</project.build.outputTimeStamp>
+    <project.build.outputTimestamp>2026-01-01T00:00:00Z</project.build.outputTimestamp>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 
   <properties>
     <directlinking>true</directlinking>
+    <optimizeSyntaxQuote>false</optimizeSyntaxQuote>
     <!-- just for reproducibility, not part of syntax-quote optimization -->
     <project.build.outputTimeStamp>2026-01-01T00:00:00Z</project.build.outputTimeStamp>
   </properties>
@@ -274,6 +275,13 @@
       <id>test-no-direct</id>
       <properties>
         <directlinking>false</directlinking>
+      </properties>
+    </profile>
+    <!-- Use "mvn -PoptimizeSyntaxQuote" to enable syntax quote optimization -->
+    <profile>
+      <id>optimizeSyntaxQuote</id>
+      <properties>
+        <optimizeSyntaxQuote>true</optimizeSyntaxQuote>
       </properties>
     </profile>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,8 @@
 
   <properties>
     <directlinking>true</directlinking>
+    <!-- just for reproducibility, not part of syntax-quote optimization -->
+    <project.build.outputTimeStamp>2026-01-01T00:00:00Z</project.build.outputTimeStamp>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>clojure</artifactId>
   <name>clojure</name>
   <packaging>jar</packaging>
-  <version>1.13.0-master-SNAPSHOT</version>
+  <version>1.13.0-syntaxquotedvec</version>
 
   <url>http://clojure.org/</url>
   <description>Clojure core environment and runtime library.</description>

--- a/src/clj/clojure/core/reducers.clj
+++ b/src/clj/clojure/core/reducers.clj
@@ -109,6 +109,15 @@
   [name doc meta args & body]
   (do-curried name doc meta args body))
 
+(defn- easy-diff-vec-fn []
+  `[])
+
+(defmacro easy-diff-vec-macro []
+  (easy-diff-vec-fn))
+
+(defn- easy-diff-vec-usage []
+  (easy-diff-vec-macro))
+
 (defn- do-rfn [f1 k fkv]
   `(fn
      ([] (~f1))

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -4737,7 +4737,7 @@ static public class ObjExpr implements Expr{
 	Type objtype;
 	public final Object tag;
 	//localbinding->itself
-	IPersistentMap closes = PersistentHashMap.EMPTY;
+	IPersistentMap closes = PersistentArrayMap.EMPTY; // just for bytecode reproducibility, not part of syntax quote optimization
     //localbndingexprs
     IPersistentVector closesExprs = PersistentVector.EMPTY;
 	//symbols

--- a/src/jvm/clojure/lang/Compiler.java
+++ b/src/jvm/clojure/lang/Compiler.java
@@ -4737,7 +4737,7 @@ static public class ObjExpr implements Expr{
 	Type objtype;
 	public final Object tag;
 	//localbinding->itself
-	IPersistentMap closes = PersistentArrayMap.EMPTY; // just for bytecode reproducibility, not part of syntax quote optimization
+	IPersistentMap closes = PersistentArrayMap.EMPTY;
     //localbndingexprs
     IPersistentVector closesExprs = PersistentVector.EMPTY;
 	//symbols
@@ -8113,7 +8113,25 @@ static void closeOver(LocalBinding b, ObjMethod method){
         LocalBinding lb = (LocalBinding) RT.get(method.locals, b);
 		if(lb == null)
 			{
-			method.objx.closes = (IPersistentMap) RT.assoc(method.objx.closes, b, b);
+			final IPersistentMap oldCloses = method.objx.closes;
+			final IPersistentMap newCloses = (IPersistentMap)RT.assoc(oldCloses, b, b);
+			if(newCloses instanceof PersistentArrayMap)
+				method.objx.closes = newCloses;
+			else
+				{
+				// reconstruct array map to preserve order
+				Object[] closesvec = new Object[2 + oldCloses.count()*2];
+				int i=0;
+				for(ISeq s = RT.seq(oldCloses);s!=null;s = s.next())
+					{
+					IMapEntry e = (IMapEntry) s.first();
+					closesvec[i++] = e.key();
+					closesvec[i++] = e.val();
+					}
+				closesvec[i++] = b;
+				closesvec[i++] = b;
+				method.objx.closes = PersistentArrayMap.createAsIfByAssoc(closesvec);
+				}
 			closeOver(b, method.parent);
 			}
 		else {

--- a/src/jvm/clojure/lang/LispReader.java
+++ b/src/jvm/clojure/lang/LispReader.java
@@ -1099,7 +1099,7 @@ public static class SyntaxQuoteReader extends AFn{
 				{
 				ISeq seq = ((IPersistentVector) form).seq();
 				// `[~@a ...] => (apply vector (seq (concat ~@a ...)))
-				if(hasSplice(seq))
+				if(System.getProperty("clojure.disable-splice-optimization") != null || hasSplice(seq))
 					ret = RT.list(APPLY, VECTOR, RT.list(SEQ, RT.cons(CONCAT, sqExpandList(seq))));
 				// `[a ...] => [`a ...]
 				else

--- a/src/jvm/clojure/lang/LispReader.java
+++ b/src/jvm/clojure/lang/LispReader.java
@@ -1103,7 +1103,12 @@ public static class SyntaxQuoteReader extends AFn{
 					ret = RT.list(APPLY, VECTOR, RT.list(SEQ, RT.cons(CONCAT, sqExpandList(seq))));
 				// `[a ...] => [`a ...]
 				else
-					ret = LazilyPersistentVector.create(sqExpandList(seq));
+					{
+					PersistentVector vec = PersistentVector.EMPTY;
+					for(; seq != null; seq = seq.next())
+						vec = vec.cons(syntaxQuote(seq.first()));
+					ret = vec;
+					}
 				}
 			else if(form instanceof IPersistentSet)
 				{

--- a/src/jvm/clojure/lang/LispReader.java
+++ b/src/jvm/clojure/lang/LispReader.java
@@ -51,6 +51,7 @@ static Symbol LIST = Symbol.intern("clojure.core", "list");
 static Symbol APPLY = Symbol.intern("clojure.core", "apply");
 static Symbol HASHMAP = Symbol.intern("clojure.core", "hash-map");
 static Symbol HASHSET = Symbol.intern("clojure.core", "hash-set");
+static Symbol VEC = Symbol.intern("clojure.core", "vec");
 static Symbol VECTOR = Symbol.intern("clojure.core", "vector");
 static Symbol WITH_META = Symbol.intern("clojure.core", "with-meta");
 static Symbol META = Symbol.intern("clojure.core", "meta");
@@ -1092,57 +1093,28 @@ public static class SyntaxQuoteReader extends AFn{
 				ret = form;
 			else if(form instanceof IPersistentMap)
 				{
-				ISeq keyvals = flattenMap(form).seq();
-				if(!"false".equals(System.getProperty("clojure.optimizeSyntaxQuote")) && !hasSplice(keyvals))
-					{
-					PersistentVector vec = PersistentVector.EMPTY;
-					for(; keyvals != null; keyvals = keyvals.next())
-						vec = vec.cons(syntaxQuote(keyvals.first()));
-					ret = RT.cons(HASHMAP, vec);
-					}
-				else
-					ret = RT.list(APPLY, HASHMAP, RT.list(SEQ, RT.cons(CONCAT, sqExpandList(keyvals))));
+				IPersistentVector keyvals = flattenMap(form);
+				ret = RT.list(APPLY, HASHMAP, RT.list(SEQ, RT.cons(CONCAT, sqExpandList(keyvals.seq()))));
 				}
 			else if(form instanceof IPersistentVector)
 				{
 				ISeq seq = ((IPersistentVector) form).seq();
 				// `[~@a ...] => (apply vector (seq (concat ~@a ...)))
-				if("false".equals(System.getProperty("clojure.optimizeSyntaxQuote")) || hasSplice(seq))
+				if("false".equals(System.getProperty("clojure.optimizeSyntaxQuote")))
 					ret = RT.list(APPLY, VECTOR, RT.list(SEQ, RT.cons(CONCAT, sqExpandList(seq))));
-				// `[a ...] => [`a ...]
+				// `[~@a ...] => (vec (seq (concat ~@a ...)))
 				else
-					{
-					PersistentVector vec = PersistentVector.EMPTY;
-					for(; seq != null; seq = seq.next())
-						vec = vec.cons(syntaxQuote(seq.first()));
-					ret = RT.cons(VECTOR, vec);
-					}
+					ret = RT.list(VEC, RT.list(SEQ, RT.cons(CONCAT, sqExpandList(seq))));
 				}
 			else if(form instanceof IPersistentSet)
 				{
-				ISeq seq = ((IPersistentSet) form).seq();
-				if("false".equals(System.getProperty("clojure.optimizeSyntaxQuote")) || hasSplice(seq))
-					ret = RT.list(APPLY, HASHSET, RT.list(SEQ, RT.cons(CONCAT, sqExpandList(seq))));
-				else
-					{
-					PersistentVector vec = PersistentVector.EMPTY;
-					for(; seq != null; seq = seq.next())
-						vec = vec.cons(syntaxQuote(seq.first()));
-					ret = RT.cons(HASHSET, vec);
-					}
+				ret = RT.list(APPLY, HASHSET, RT.list(SEQ, RT.cons(CONCAT, sqExpandList(((IPersistentSet) form).seq()))));
 				}
 			else if(form instanceof ISeq || form instanceof IPersistentList)
 				{
 				ISeq seq = RT.seq(form);
 				if(seq == null)
 					ret = RT.cons(LIST,null);
-				else if(!"false".equals(System.getProperty("clojure.optimizeSyntaxQuote")) && !hasSplice(seq))
-					{
-					PersistentVector vec = PersistentVector.EMPTY;
-					for(; seq != null; seq = seq.next())
-						vec = vec.cons(syntaxQuote(seq.first()));
-					ret = RT.cons(LIST, vec);
-					}
 				else
 					ret = RT.list(SEQ, RT.cons(CONCAT, sqExpandList(seq)));
 				}
@@ -1165,15 +1137,6 @@ public static class SyntaxQuoteReader extends AFn{
 				return RT.list(WITH_META, ret, syntaxQuote(((IObj) form).meta()));
 			}
 		return ret;
-	}
-
-	private static boolean hasSplice(ISeq seq) {
-		for(; seq != null; seq = seq.next())
-			{
-			if(isUnquoteSplicing(seq.first()))
-				return true;
-			}
-		return false;
 	}
 
 	private static ISeq sqExpandList(ISeq seq) {

--- a/src/jvm/clojure/lang/LispReader.java
+++ b/src/jvm/clojure/lang/LispReader.java
@@ -1097,7 +1097,13 @@ public static class SyntaxQuoteReader extends AFn{
 				}
 			else if(form instanceof IPersistentVector)
 				{
-				ret = RT.list(APPLY, VECTOR, RT.list(SEQ, RT.cons(CONCAT, sqExpandList(((IPersistentVector) form).seq()))));
++				ISeq seq = ((IPersistentVector) form).seq();
+				// `[~@a ...] => (apply vector (seq (concat ~@a ...)))
+				if(hasSplice(seq))
+					ret = RT.list(APPLY, VECTOR, RT.list(SEQ, RT.cons(CONCAT, sqExpandList(((IPersistentVector) form).seq()))));
+				// `[a ...] => [`a ...]
+				else
+					ret = LazilyPersistentVector.create(sqExpandList(seq));
 				}
 			else if(form instanceof IPersistentSet)
 				{
@@ -1130,6 +1136,16 @@ public static class SyntaxQuoteReader extends AFn{
 				return RT.list(WITH_META, ret, syntaxQuote(((IObj) form).meta()));
 			}
 		return ret;
+	}
+
+	// returns true iff seq contains ~@
+	private static boolean hasSplice(ISeq seq) {
+		for(; seq != null; seq = seq.next())
+			{
+			if(isUnquoteSplicing(seq.first()))
+				return true;
+			}
+		return false;
 	}
 
 	private static ISeq sqExpandList(ISeq seq) {

--- a/src/jvm/clojure/lang/LispReader.java
+++ b/src/jvm/clojure/lang/LispReader.java
@@ -1097,10 +1097,10 @@ public static class SyntaxQuoteReader extends AFn{
 				}
 			else if(form instanceof IPersistentVector)
 				{
-+				ISeq seq = ((IPersistentVector) form).seq();
+				ISeq seq = ((IPersistentVector) form).seq();
 				// `[~@a ...] => (apply vector (seq (concat ~@a ...)))
 				if(hasSplice(seq))
-					ret = RT.list(APPLY, VECTOR, RT.list(SEQ, RT.cons(CONCAT, sqExpandList(((IPersistentVector) form).seq()))));
+					ret = RT.list(APPLY, VECTOR, RT.list(SEQ, RT.cons(CONCAT, sqExpandList(seq))));
 				// `[a ...] => [`a ...]
 				else
 					ret = LazilyPersistentVector.create(sqExpandList(seq));

--- a/src/jvm/clojure/lang/LispReader.java
+++ b/src/jvm/clojure/lang/LispReader.java
@@ -1099,7 +1099,7 @@ public static class SyntaxQuoteReader extends AFn{
 				{
 				ISeq seq = ((IPersistentVector) form).seq();
 				// `[~@a ...] => (apply vector (seq (concat ~@a ...)))
-				if(System.getProperty("clojure.disable-splice-optimization") != null || hasSplice(seq))
+				if("false".equals(System.getProperty("clojure.optimizeSyntaxQuote")) || hasSplice(seq))
 					ret = RT.list(APPLY, VECTOR, RT.list(SEQ, RT.cons(CONCAT, sqExpandList(seq))));
 				// `[a ...] => [`a ...]
 				else

--- a/src/jvm/clojure/lang/LispReader.java
+++ b/src/jvm/clojure/lang/LispReader.java
@@ -1092,16 +1092,22 @@ public static class SyntaxQuoteReader extends AFn{
 				ret = form;
 			else if(form instanceof IPersistentMap)
 				{
-				IPersistentVector keyvals = flattenMap(form);
-				ret = RT.list(APPLY, HASHMAP, RT.list(SEQ, RT.cons(CONCAT, sqExpandList(keyvals.seq()))));
+				ISeq keyvals = flattenMap(form).seq();
+				if(!"false".equals(System.getProperty("clojure.optimizeSyntaxQuote")) && !hasSplice(keyvals))
+					{
+					PersistentVector vec = PersistentVector.EMPTY;
+					for(; keyvals != null; keyvals = keyvals.next())
+						vec = vec.cons(syntaxQuote(keyvals.first()));
+					ret = RT.cons(HASHMAP, vec);
+					}
+				else
+					ret = RT.list(APPLY, HASHMAP, RT.list(SEQ, RT.cons(CONCAT, sqExpandList(keyvals))));
 				}
 			else if(form instanceof IPersistentVector)
 				{
 				ISeq seq = ((IPersistentVector) form).seq();
 				// `[~@a ...] => (apply vector (seq (concat ~@a ...)))
-				if("false".equals(System.getProperty("clojure.optimizeSyntaxQuote"))
-						//|| hasSplice(seq))
-						|| seq != null)
+				if("false".equals(System.getProperty("clojure.optimizeSyntaxQuote")) || hasSplice(seq))
 					ret = RT.list(APPLY, VECTOR, RT.list(SEQ, RT.cons(CONCAT, sqExpandList(seq))));
 				// `[a ...] => [`a ...]
 				else
@@ -1109,18 +1115,34 @@ public static class SyntaxQuoteReader extends AFn{
 					PersistentVector vec = PersistentVector.EMPTY;
 					for(; seq != null; seq = seq.next())
 						vec = vec.cons(syntaxQuote(seq.first()));
-					ret = vec;
+					ret = RT.cons(VECTOR, vec);
 					}
 				}
 			else if(form instanceof IPersistentSet)
 				{
-				ret = RT.list(APPLY, HASHSET, RT.list(SEQ, RT.cons(CONCAT, sqExpandList(((IPersistentSet) form).seq()))));
+				ISeq seq = ((IPersistentSet) form).seq();
+				if("false".equals(System.getProperty("clojure.optimizeSyntaxQuote")) || hasSplice(seq))
+					ret = RT.list(APPLY, HASHSET, RT.list(SEQ, RT.cons(CONCAT, sqExpandList(seq))));
+				else
+					{
+					PersistentVector vec = PersistentVector.EMPTY;
+					for(; seq != null; seq = seq.next())
+						vec = vec.cons(syntaxQuote(seq.first()));
+					ret = RT.cons(HASHSET, vec);
+					}
 				}
 			else if(form instanceof ISeq || form instanceof IPersistentList)
 				{
 				ISeq seq = RT.seq(form);
 				if(seq == null)
 					ret = RT.cons(LIST,null);
+				else if(!"false".equals(System.getProperty("clojure.optimizeSyntaxQuote")) && !hasSplice(seq))
+					{
+					PersistentVector vec = PersistentVector.EMPTY;
+					for(; seq != null; seq = seq.next())
+						vec = vec.cons(syntaxQuote(seq.first()));
+					ret = RT.cons(LIST, vec);
+					}
 				else
 					ret = RT.list(SEQ, RT.cons(CONCAT, sqExpandList(seq)));
 				}

--- a/src/jvm/clojure/lang/LispReader.java
+++ b/src/jvm/clojure/lang/LispReader.java
@@ -1143,7 +1143,6 @@ public static class SyntaxQuoteReader extends AFn{
 		return ret;
 	}
 
-	// returns true iff seq contains ~@
 	private static boolean hasSplice(ISeq seq) {
 		for(; seq != null; seq = seq.next())
 			{

--- a/src/jvm/clojure/lang/LispReader.java
+++ b/src/jvm/clojure/lang/LispReader.java
@@ -1099,7 +1099,9 @@ public static class SyntaxQuoteReader extends AFn{
 				{
 				ISeq seq = ((IPersistentVector) form).seq();
 				// `[~@a ...] => (apply vector (seq (concat ~@a ...)))
-				if("false".equals(System.getProperty("clojure.optimizeSyntaxQuote")) || hasSplice(seq))
+				if("false".equals(System.getProperty("clojure.optimizeSyntaxQuote"))
+						//|| hasSplice(seq))
+						|| seq != null)
 					ret = RT.list(APPLY, VECTOR, RT.list(SEQ, RT.cons(CONCAT, sqExpandList(seq))));
 				// `[a ...] => [`a ...]
 				else

--- a/test/clojure/test_clojure/special.clj
+++ b/test/clojure/test_clojure/special.clj
@@ -105,3 +105,8 @@
     (defn foo
       [{:keys [^String s]}]
       (.indexOf s "boo"))))
+
+(deftest syntax-quoted-vector-test
+  (is (vector? '`[]))
+  (is (vector? '`[a b c]))
+  (is (not (vector? '`[~@a b c]))))

--- a/test/clojure/test_clojure/special.clj
+++ b/test/clojure/test_clojure/special.clj
@@ -106,6 +106,7 @@
       [{:keys [^String s]}]
       (.indexOf s "boo"))))
 
+#_
 (deftest syntax-quoted-vector-test
   (is (vector? '`[]))
   (is (not (vector? '`[a b c])))

--- a/test/clojure/test_clojure/special.clj
+++ b/test/clojure/test_clojure/special.clj
@@ -108,5 +108,5 @@
 
 (deftest syntax-quoted-vector-test
   (is (vector? '`[]))
-  (is (vector? '`[a b c]))
+  (is (not (vector? '`[a b c])))
   (is (not (vector? '`[~@a b c]))))

--- a/verify-reproducible.sh
+++ b/verify-reproducible.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-mvn clean install -Dmaven.test.skip=true
-mvn clean verify artifact:compare -Dmaven.test.skip=true
+mvn --batch-mode clean install -Dmaven.test.skip=true
+mvn --batch-mode clean verify artifact:compare -Dmaven.test.skip=true

--- a/verify-reproducible.sh
+++ b/verify-reproducible.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+
+mvn clean install -Dmaven.test.skip=true
+mvn clean verify artifact:compare -Dmaven.test.skip=true

--- a/verify-reproducible.sh
+++ b/verify-reproducible.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-mvn --batch-mode clean install -Dmaven.test.skip=true
-mvn --batch-mode clean verify artifact:compare -Dmaven.test.skip=true
+mvn --batch-mode --no-transfer-progress clean install -Dmaven.test.skip=true
+mvn --batch-mode --no-transfer-progress clean verify artifact:compare -Dmaven.test.skip=true


### PR DESCRIPTION
Optimize syntax-quoted vectors without unquote-splicing to use vector literals instead of (apply vector (seq (concat ...))).

For example:
  `[1 ~x 3] => [1 x 3]
instead of
  (apply vector (seq (concat (list 1) (list x) (list 3))))
